### PR TITLE
Verify template_name and vm_name per proxmox requirements

### DIFF
--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -237,8 +238,14 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	if c.Node == "" {
 		errs = packersdk.MultiErrorAppend(errs, errors.New("node must be specified"))
 	}
-	if strings.ContainsAny(c.TemplateName, " ") {
-		errs = packersdk.MultiErrorAppend(errs, errors.New("template_name must not contain spaces"))
+	
+	// Verify VM Name and Template Name are a valid DNS Names
+	re := regexp.MustCompile(`^(?:(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?)\.)*(?:[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?))$`)
+	if !re.MatchString(c.VMName) {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("vm_name must be a valid DNS name"))
+	}
+	if !re.MatchString(c.TemplateName) {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("template_name must be a valid DNS name"))
 	}
 	for idx := range c.NICs {
 		if c.NICs[idx].Bridge == "" {

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -1,134 +1,332 @@
+//go:generate packer-sdc struct-markdown
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,nicConfig,diskConfig,vgaConfig,additionalISOsConfig
+
 package proxmox
 
 import (
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
 	"strings"
-	"testing"
+	"time"
 
+	"github.com/hashicorp/packer-plugin-sdk/bootcommand"
+	"github.com/hashicorp/packer-plugin-sdk/common"
+	"github.com/hashicorp/packer-plugin-sdk/communicator"
+	"github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"github.com/hashicorp/packer-plugin-sdk/uuid"
+	"github.com/mitchellh/mapstructure"
 )
 
-func mandatoryConfig(t *testing.T) map[string]interface{} {
-	return map[string]interface{}{
-		"proxmox_url":  "https://my-proxmox.my-domain:8006/api2/json",
-		"username":     "apiuser@pve",
-		"password":     "supersecret",
-		"node":         "my-proxmox",
-		"ssh_username": "root",
-	}
+type Config struct {
+	common.PackerConfig    `mapstructure:",squash"`
+	commonsteps.HTTPConfig `mapstructure:",squash"`
+	bootcommand.BootConfig `mapstructure:",squash"`
+	BootKeyInterval        time.Duration       `mapstructure:"boot_key_interval"`
+	Comm                   communicator.Config `mapstructure:",squash"`
+
+	ProxmoxURLRaw      string `mapstructure:"proxmox_url"`
+	proxmoxURL         *url.URL
+	SkipCertValidation bool   `mapstructure:"insecure_skip_tls_verify"`
+	Username           string `mapstructure:"username"`
+	Password           string `mapstructure:"password"`
+	Token              string `mapstructure:"token"`
+	Node               string `mapstructure:"node"`
+	Pool               string `mapstructure:"pool"`
+
+	VMName string `mapstructure:"vm_name"`
+	VMID   int    `mapstructure:"vm_id"`
+
+	Boot           string       `mapstructure:"boot"`
+	Memory         int          `mapstructure:"memory"`
+	Cores          int          `mapstructure:"cores"`
+	CPUType        string       `mapstructure:"cpu_type"`
+	Sockets        int          `mapstructure:"sockets"`
+	OS             string       `mapstructure:"os"`
+	VGA            vgaConfig    `mapstructure:"vga"`
+	NICs           []nicConfig  `mapstructure:"network_adapters"`
+	Disks          []diskConfig `mapstructure:"disks"`
+	Agent          bool         `mapstructure:"qemu_agent"`
+	SCSIController string       `mapstructure:"scsi_controller"`
+	Onboot         bool         `mapstructure:"onboot"`
+	DisableKVM     bool         `mapstructure:"disable_kvm"`
+
+	TemplateName        string `mapstructure:"template_name"`
+	TemplateDescription string `mapstructure:"template_description"`
+
+	CloudInit            bool   `mapstructure:"cloud_init"`
+	CloudInitStoragePool string `mapstructure:"cloud_init_storage_pool"`
+
+	AdditionalISOFiles []additionalISOsConfig `mapstructure:"additional_iso_files"`
+	VMInterface        string                 `mapstructure:"vm_interface"`
+
+	Ctx interpolate.Context `mapstructure-to-hcl2:",skip"`
 }
 
-func TestRequiredParameters(t *testing.T) {
-	var c Config
-	_, _, err := c.Prepare(&c, make(map[string]interface{}))
-	if err == nil {
-		t.Fatal("Expected empty configuration to fail")
-	}
-	errs, ok := err.(*packersdk.MultiError)
-	if !ok {
-		t.Fatal("Expected errors to be packersdk.MultiError")
+type additionalISOsConfig struct {
+	commonsteps.ISOConfig `mapstructure:",squash"`
+	Device                string `mapstructure:"device"`
+	ISOFile               string `mapstructure:"iso_file"`
+	ISOStoragePool        string `mapstructure:"iso_storage_pool"`
+	Unmount               bool   `mapstructure:"unmount"`
+	ShouldUploadISO       bool   `mapstructure-to-hcl2:",skip"`
+	DownloadPathKey       string `mapstructure-to-hcl2:",skip"`
+}
+
+type nicConfig struct {
+	Model        string `mapstructure:"model"`
+	PacketQueues int    `mapstructure:"packet_queues"`
+	MACAddress   string `mapstructure:"mac_address"`
+	Bridge       string `mapstructure:"bridge"`
+	VLANTag      string `mapstructure:"vlan_tag"`
+	Firewall     bool   `mapstructure:"firewall"`
+}
+type diskConfig struct {
+	Type            string `mapstructure:"type"`
+	StoragePool     string `mapstructure:"storage_pool"`
+	StoragePoolType string `mapstructure:"storage_pool_type"`
+	Size            string `mapstructure:"disk_size"`
+	CacheMode       string `mapstructure:"cache_mode"`
+	DiskFormat      string `mapstructure:"format"`
+	IOThread        bool   `mapstructure:"io_thread"`
+}
+type vgaConfig struct {
+	Type   string `mapstructure:"type"`
+	Memory int    `mapstructure:"memory"`
+}
+
+func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []string, error) {
+	// Agent defaults to true
+	c.Agent = true
+	// Do not add a cloud-init cdrom by default
+	c.CloudInit = false
+
+	var md mapstructure.Metadata
+	err := config.Decode(upper, &config.DecodeOpts{
+		Metadata:           &md,
+		Interpolate:        true,
+		InterpolateContext: &c.Ctx,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{
+				"boot_command",
+			},
+		},
+	}, raws...)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	required := []string{"username", "password", "proxmox_url", "node", "ssh_username"}
-	for _, param := range required {
-		found := false
-		for _, err := range errs.Errors {
-			if strings.Contains(err.Error(), param) {
-				found = true
-				break
+	var errs *packersdk.MultiError
+	var warnings []string
+
+	packersdk.LogSecretFilter.Set(c.Password)
+
+	// Defaults
+	if c.ProxmoxURLRaw == "" {
+		c.ProxmoxURLRaw = os.Getenv("PROXMOX_URL")
+	}
+	if c.Username == "" {
+		c.Username = os.Getenv("PROXMOX_USERNAME")
+	}
+	if c.Password == "" {
+		c.Password = os.Getenv("PROXMOX_PASSWORD")
+	}
+	if c.Token == "" {
+		c.Token = os.Getenv("PROXMOX_TOKEN")
+	}
+	if c.BootKeyInterval == 0 && os.Getenv(bootcommand.PackerKeyEnv) != "" {
+		var err error
+		c.BootKeyInterval, err = time.ParseDuration(os.Getenv(bootcommand.PackerKeyEnv))
+		if err != nil {
+			errs = packersdk.MultiErrorAppend(errs, err)
+		}
+	}
+	if c.BootKeyInterval == 0 {
+		c.BootKeyInterval = 5 * time.Millisecond
+	}
+
+	if c.VMName == "" {
+		// Default to packer-[time-ordered-uuid]
+		c.VMName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
+	}
+	if c.Memory < 16 {
+		log.Printf("Memory %d is too small, using default: 512", c.Memory)
+		c.Memory = 512
+	}
+	if c.Cores < 1 {
+		log.Printf("Number of cores %d is too small, using default: 1", c.Cores)
+		c.Cores = 1
+	}
+	if c.Sockets < 1 {
+		log.Printf("Number of sockets %d is too small, using default: 1", c.Sockets)
+		c.Sockets = 1
+	}
+	if c.CPUType == "" {
+		log.Printf("CPU type not set, using default 'kvm64'")
+		c.CPUType = "kvm64"
+	}
+	if c.OS == "" {
+		log.Printf("OS not set, using default 'other'")
+		c.OS = "other"
+	}
+	for idx := range c.NICs {
+		if c.NICs[idx].Model == "" {
+			log.Printf("NIC %d model not set, using default 'e1000'", idx)
+			c.NICs[idx].Model = "e1000"
+		}
+	}
+	for idx := range c.Disks {
+		if c.Disks[idx].Type == "" {
+			log.Printf("Disk %d type not set, using default 'scsi'", idx)
+			c.Disks[idx].Type = "scsi"
+		}
+		if c.Disks[idx].Size == "" {
+			log.Printf("Disk %d size not set, using default '20G'", idx)
+			c.Disks[idx].Size = "20G"
+		}
+		if c.Disks[idx].CacheMode == "" {
+			log.Printf("Disk %d cache mode not set, using default 'none'", idx)
+			c.Disks[idx].CacheMode = "none"
+		}
+		if c.Disks[idx].IOThread {
+			// io thread is only supported by virtio-scsi-single controller
+			if c.SCSIController != "virtio-scsi-single" {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("io thread option requires virtio-scsi-single controller"))
+			} else {
+				// ... and only for virtio and scsi disks
+				if !(c.Disks[idx].Type == "scsi" || c.Disks[idx].Type == "virtio") {
+					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("io thread option requires scsi or a virtio disk"))
+				}
 			}
 		}
-		if !found {
-			t.Errorf("Expected error about missing parameter %q", required)
+		// For any storage pool types which aren't in rxStorageTypes in proxmox-api/proxmox/config_qemu.go:890
+		// (currently zfspool|lvm|rbd|cephfs), the format parameter is mandatory. Make sure this is still up to date
+		// when updating the vendored code!
+		if !contains([]string{"zfspool", "lvm", "rbd", "cephfs"}, c.Disks[idx].StoragePoolType) && c.Disks[idx].DiskFormat == "" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disk format must be specified for pool type %q", c.Disks[idx].StoragePoolType))
 		}
 	}
+	if c.SCSIController == "" {
+		log.Printf("SCSI controller not set, using default 'lsi'")
+		c.SCSIController = "lsi"
+	}
+
+	errs = packersdk.MultiErrorAppend(errs, c.Comm.Prepare(&c.Ctx)...)
+	errs = packersdk.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.Ctx)...)
+	errs = packersdk.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.Ctx)...)
+
+	// Required configurations that will display errors if not set
+	if c.Username == "" {
+		errs = packersdk.MultiErrorAppend(errs, errors.New("username must be specified"))
+	}
+	if c.Password == "" && c.Token == "" {
+		errs = packersdk.MultiErrorAppend(errs, errors.New("password or token must be specified"))
+	}
+	if c.ProxmoxURLRaw == "" {
+		errs = packersdk.MultiErrorAppend(errs, errors.New("proxmox_url must be specified"))
+	}
+	if c.proxmoxURL, err = url.Parse(c.ProxmoxURLRaw); err != nil {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Could not parse proxmox_url: %s", err))
+	}
+	if c.Node == "" {
+		errs = packersdk.MultiErrorAppend(errs, errors.New("node must be specified"))
+	}
+	
+	// Verify VM Name and Template Name are a valid DNS Names
+	re := regexp.MustCompile(`^(?:(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?)\.)*(?:[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?))$`)
+	if !re.MatchString(c.VMName) {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("vm_name must be a valid DNS name"))
+	}
+	if c.TemplateName != "" && !re.MatchString(c.TemplateName) {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("template_name must be a valid DNS name"))
+	}
+	for idx := range c.NICs {
+		if c.NICs[idx].Bridge == "" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("network_adapters[%d].bridge must be specified", idx))
+		}
+		if c.NICs[idx].Model != "virtio" && c.NICs[idx].PacketQueues > 0 {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("network_adapters[%d].packet_queues can only be set for 'virtio' driver", idx))
+		}
+	}
+	for idx := range c.Disks {
+		if c.Disks[idx].StoragePool == "" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disks[%d].storage_pool must be specified", idx))
+		}
+		if c.Disks[idx].StoragePoolType == "" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disks[%d].storage_pool_type must be specified", idx))
+		}
+	}
+	for idx := range c.AdditionalISOFiles {
+		// Check AdditionalISO config
+		// Either a pre-uploaded ISO should be referenced in iso_file, OR a URL
+		// (possibly to a local file) to an ISO file that will be downloaded and
+		// then uploaded to Proxmox.
+		if c.AdditionalISOFiles[idx].ISOFile != "" {
+			c.AdditionalISOFiles[idx].ShouldUploadISO = false
+		} else {
+			c.AdditionalISOFiles[idx].DownloadPathKey = "downloaded_additional_iso_path_" + strconv.Itoa(idx)
+			isoWarnings, isoErrors := c.AdditionalISOFiles[idx].ISOConfig.Prepare(&c.Ctx)
+			errs = packersdk.MultiErrorAppend(errs, isoErrors...)
+			warnings = append(warnings, isoWarnings...)
+			c.AdditionalISOFiles[idx].ShouldUploadISO = true
+		}
+		if c.AdditionalISOFiles[idx].Device == "" {
+			log.Printf("AdditionalISOFile %d Device not set, using default 'ide3'", idx)
+			c.AdditionalISOFiles[idx].Device = "ide3"
+		}
+		if strings.HasPrefix(c.AdditionalISOFiles[idx].Device, "ide") {
+			busnumber, err := strconv.Atoi(c.AdditionalISOFiles[idx].Device[3:])
+			if err != nil {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("%s is not a valid bus index", c.AdditionalISOFiles[idx].Device[3:]))
+			}
+			if busnumber == 2 {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("IDE bus 2 is used by boot ISO"))
+			}
+			if busnumber > 3 {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("IDE bus index can't be higher than 3"))
+			}
+		}
+		if strings.HasPrefix(c.AdditionalISOFiles[idx].Device, "sata") {
+			busnumber, err := strconv.Atoi(c.AdditionalISOFiles[idx].Device[4:])
+			if err != nil {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("%s is not a valid bus index", c.AdditionalISOFiles[idx].Device[4:]))
+			}
+			if busnumber > 5 {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("SATA bus index can't be higher than 5"))
+			}
+		}
+		if strings.HasPrefix(c.AdditionalISOFiles[idx].Device, "scsi") {
+			busnumber, err := strconv.Atoi(c.AdditionalISOFiles[idx].Device[4:])
+			if err != nil {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("%s is not a valid bus index", c.AdditionalISOFiles[idx].Device[4:]))
+			}
+			if busnumber > 30 {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("SCSI bus index can't be higher than 30"))
+			}
+		}
+		if (c.AdditionalISOFiles[idx].ISOFile == "" && len(c.AdditionalISOFiles[idx].ISOConfig.ISOUrls) == 0) || (c.AdditionalISOFiles[idx].ISOFile != "" && len(c.AdditionalISOFiles[idx].ISOConfig.ISOUrls) != 0) {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("either iso_file or iso_url, but not both, must be specified for AdditionalISO file %s", c.AdditionalISOFiles[idx].Device))
+		}
+	}
+
+	if errs != nil && len(errs.Errors) > 0 {
+		return nil, warnings, errs
+	}
+	return nil, warnings, nil
 }
 
-func TestAgentSetToFalse(t *testing.T) {
-	cfg := mandatoryConfig(t)
-	cfg["qemu_agent"] = false
-
-	var c Config
-	_, _, err := c.Prepare(&c, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if c.Agent != false {
-		t.Errorf("Expected Agent to be false, got %t", c.Agent)
-	}
-}
-
-func TestPacketQueueSupportForNetworkAdapters(t *testing.T) {
-	drivertests := []struct {
-		expectedToFail bool
-		model          string
-	}{
-		{expectedToFail: false, model: "virtio"},
-		{expectedToFail: true, model: "e1000"},
-		{expectedToFail: true, model: "e1000-82540em"},
-		{expectedToFail: true, model: "e1000-82544gc"},
-		{expectedToFail: true, model: "e1000-82545em"},
-		{expectedToFail: true, model: "i82551"},
-		{expectedToFail: true, model: "i82557b"},
-		{expectedToFail: true, model: "i82559er"},
-		{expectedToFail: true, model: "ne2k_isa"},
-		{expectedToFail: true, model: "ne2k_pci"},
-		{expectedToFail: true, model: "pcnet"},
-		{expectedToFail: true, model: "rtl8139"},
-		{expectedToFail: true, model: "vmxnet3"},
-	}
-
-	for _, tt := range drivertests {
-		device := make(map[string]interface{})
-		device["bridge"] = "vmbr0"
-		device["model"] = tt.model
-		device["packet_queues"] = 2
-
-		devices := make([]map[string]interface{}, 0)
-		devices = append(devices, device)
-
-		cfg := mandatoryConfig(t)
-		cfg["network_adapters"] = devices
-
-		var c Config
-		_, _, err := c.Prepare(&c, cfg)
-
-		if tt.expectedToFail == true && err == nil {
-			t.Error("expected config preparation to fail, but no error occured")
-		}
-
-		if tt.expectedToFail == false && err != nil {
-			t.Errorf("expected config preparation to succeed, but %s", err.Error())
+func contains(haystack []string, needle string) bool {
+	for _, candidate := range haystack {
+		if candidate == needle {
+			return true
 		}
 	}
-}
-
-func TestVMandTemplateName(t *testing.T) {
-	dnsnametests := []struct {
-		expectedToFail bool
-		name          string
-	}{
-		{expectedToFail: false, name: "packer"},
-		{expectedToFail: false, name: "pac.ker"},
-		{expectedToFail: true, name: "pac_ker"},
-		{expectedToFail: true, name: "pac ker"},
-	}
-
-	for _, tt := range dnsnametests {
-
-		cfg := mandatoryConfig(t)
-		cfg["vm_name"] = tt.name
-		cfg["template_name"] = tt.name
-
-		var c Config
-		_, _, err := c.Prepare(&c, cfg)
-
-		if tt.expectedToFail == true && err == nil {
-			t.Error("expected config preparation to fail, but no error occured")
-		}
-
-		if tt.expectedToFail == false && err != nil {
-			t.Errorf("expected config preparation to succeed, but %s", err.Error())
-		}
-	}
+	return false
 }

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -1,332 +1,134 @@
-//go:generate packer-sdc struct-markdown
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config,nicConfig,diskConfig,vgaConfig,additionalISOsConfig
-
 package proxmox
 
 import (
-	"errors"
-	"fmt"
-	"log"
-	"net/url"
-	"os"
-	"regexp"
-	"strconv"
 	"strings"
-	"time"
+	"testing"
 
-	"github.com/hashicorp/packer-plugin-sdk/bootcommand"
-	"github.com/hashicorp/packer-plugin-sdk/common"
-	"github.com/hashicorp/packer-plugin-sdk/communicator"
-	"github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	"github.com/hashicorp/packer-plugin-sdk/template/config"
-	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-	"github.com/hashicorp/packer-plugin-sdk/uuid"
-	"github.com/mitchellh/mapstructure"
 )
 
-type Config struct {
-	common.PackerConfig    `mapstructure:",squash"`
-	commonsteps.HTTPConfig `mapstructure:",squash"`
-	bootcommand.BootConfig `mapstructure:",squash"`
-	BootKeyInterval        time.Duration       `mapstructure:"boot_key_interval"`
-	Comm                   communicator.Config `mapstructure:",squash"`
-
-	ProxmoxURLRaw      string `mapstructure:"proxmox_url"`
-	proxmoxURL         *url.URL
-	SkipCertValidation bool   `mapstructure:"insecure_skip_tls_verify"`
-	Username           string `mapstructure:"username"`
-	Password           string `mapstructure:"password"`
-	Token              string `mapstructure:"token"`
-	Node               string `mapstructure:"node"`
-	Pool               string `mapstructure:"pool"`
-
-	VMName string `mapstructure:"vm_name"`
-	VMID   int    `mapstructure:"vm_id"`
-
-	Boot           string       `mapstructure:"boot"`
-	Memory         int          `mapstructure:"memory"`
-	Cores          int          `mapstructure:"cores"`
-	CPUType        string       `mapstructure:"cpu_type"`
-	Sockets        int          `mapstructure:"sockets"`
-	OS             string       `mapstructure:"os"`
-	VGA            vgaConfig    `mapstructure:"vga"`
-	NICs           []nicConfig  `mapstructure:"network_adapters"`
-	Disks          []diskConfig `mapstructure:"disks"`
-	Agent          bool         `mapstructure:"qemu_agent"`
-	SCSIController string       `mapstructure:"scsi_controller"`
-	Onboot         bool         `mapstructure:"onboot"`
-	DisableKVM     bool         `mapstructure:"disable_kvm"`
-
-	TemplateName        string `mapstructure:"template_name"`
-	TemplateDescription string `mapstructure:"template_description"`
-
-	CloudInit            bool   `mapstructure:"cloud_init"`
-	CloudInitStoragePool string `mapstructure:"cloud_init_storage_pool"`
-
-	AdditionalISOFiles []additionalISOsConfig `mapstructure:"additional_iso_files"`
-	VMInterface        string                 `mapstructure:"vm_interface"`
-
-	Ctx interpolate.Context `mapstructure-to-hcl2:",skip"`
+func mandatoryConfig(t *testing.T) map[string]interface{} {
+	return map[string]interface{}{
+		"proxmox_url":  "https://my-proxmox.my-domain:8006/api2/json",
+		"username":     "apiuser@pve",
+		"password":     "supersecret",
+		"node":         "my-proxmox",
+		"ssh_username": "root",
+	}
 }
 
-type additionalISOsConfig struct {
-	commonsteps.ISOConfig `mapstructure:",squash"`
-	Device                string `mapstructure:"device"`
-	ISOFile               string `mapstructure:"iso_file"`
-	ISOStoragePool        string `mapstructure:"iso_storage_pool"`
-	Unmount               bool   `mapstructure:"unmount"`
-	ShouldUploadISO       bool   `mapstructure-to-hcl2:",skip"`
-	DownloadPathKey       string `mapstructure-to-hcl2:",skip"`
+func TestRequiredParameters(t *testing.T) {
+	var c Config
+	_, _, err := c.Prepare(&c, make(map[string]interface{}))
+	if err == nil {
+		t.Fatal("Expected empty configuration to fail")
+	}
+	errs, ok := err.(*packersdk.MultiError)
+	if !ok {
+		t.Fatal("Expected errors to be packersdk.MultiError")
+	}
+
+	required := []string{"username", "password", "proxmox_url", "node", "ssh_username"}
+	for _, param := range required {
+		found := false
+		for _, err := range errs.Errors {
+			if strings.Contains(err.Error(), param) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected error about missing parameter %q", required)
+		}
+	}
 }
 
-type nicConfig struct {
-	Model        string `mapstructure:"model"`
-	PacketQueues int    `mapstructure:"packet_queues"`
-	MACAddress   string `mapstructure:"mac_address"`
-	Bridge       string `mapstructure:"bridge"`
-	VLANTag      string `mapstructure:"vlan_tag"`
-	Firewall     bool   `mapstructure:"firewall"`
-}
-type diskConfig struct {
-	Type            string `mapstructure:"type"`
-	StoragePool     string `mapstructure:"storage_pool"`
-	StoragePoolType string `mapstructure:"storage_pool_type"`
-	Size            string `mapstructure:"disk_size"`
-	CacheMode       string `mapstructure:"cache_mode"`
-	DiskFormat      string `mapstructure:"format"`
-	IOThread        bool   `mapstructure:"io_thread"`
-}
-type vgaConfig struct {
-	Type   string `mapstructure:"type"`
-	Memory int    `mapstructure:"memory"`
-}
+func TestAgentSetToFalse(t *testing.T) {
+	cfg := mandatoryConfig(t)
+	cfg["qemu_agent"] = false
 
-func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []string, error) {
-	// Agent defaults to true
-	c.Agent = true
-	// Do not add a cloud-init cdrom by default
-	c.CloudInit = false
-
-	var md mapstructure.Metadata
-	err := config.Decode(upper, &config.DecodeOpts{
-		Metadata:           &md,
-		Interpolate:        true,
-		InterpolateContext: &c.Ctx,
-		InterpolateFilter: &interpolate.RenderFilter{
-			Exclude: []string{
-				"boot_command",
-			},
-		},
-	}, raws...)
+	var c Config
+	_, _, err := c.Prepare(&c, cfg)
 	if err != nil {
-		return nil, nil, err
+		t.Fatal(err)
 	}
 
-	var errs *packersdk.MultiError
-	var warnings []string
-
-	packersdk.LogSecretFilter.Set(c.Password)
-
-	// Defaults
-	if c.ProxmoxURLRaw == "" {
-		c.ProxmoxURLRaw = os.Getenv("PROXMOX_URL")
+	if c.Agent != false {
+		t.Errorf("Expected Agent to be false, got %t", c.Agent)
 	}
-	if c.Username == "" {
-		c.Username = os.Getenv("PROXMOX_USERNAME")
-	}
-	if c.Password == "" {
-		c.Password = os.Getenv("PROXMOX_PASSWORD")
-	}
-	if c.Token == "" {
-		c.Token = os.Getenv("PROXMOX_TOKEN")
-	}
-	if c.BootKeyInterval == 0 && os.Getenv(bootcommand.PackerKeyEnv) != "" {
-		var err error
-		c.BootKeyInterval, err = time.ParseDuration(os.Getenv(bootcommand.PackerKeyEnv))
-		if err != nil {
-			errs = packersdk.MultiErrorAppend(errs, err)
-		}
-	}
-	if c.BootKeyInterval == 0 {
-		c.BootKeyInterval = 5 * time.Millisecond
-	}
-
-	if c.VMName == "" {
-		// Default to packer-[time-ordered-uuid]
-		c.VMName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
-	}
-	if c.Memory < 16 {
-		log.Printf("Memory %d is too small, using default: 512", c.Memory)
-		c.Memory = 512
-	}
-	if c.Cores < 1 {
-		log.Printf("Number of cores %d is too small, using default: 1", c.Cores)
-		c.Cores = 1
-	}
-	if c.Sockets < 1 {
-		log.Printf("Number of sockets %d is too small, using default: 1", c.Sockets)
-		c.Sockets = 1
-	}
-	if c.CPUType == "" {
-		log.Printf("CPU type not set, using default 'kvm64'")
-		c.CPUType = "kvm64"
-	}
-	if c.OS == "" {
-		log.Printf("OS not set, using default 'other'")
-		c.OS = "other"
-	}
-	for idx := range c.NICs {
-		if c.NICs[idx].Model == "" {
-			log.Printf("NIC %d model not set, using default 'e1000'", idx)
-			c.NICs[idx].Model = "e1000"
-		}
-	}
-	for idx := range c.Disks {
-		if c.Disks[idx].Type == "" {
-			log.Printf("Disk %d type not set, using default 'scsi'", idx)
-			c.Disks[idx].Type = "scsi"
-		}
-		if c.Disks[idx].Size == "" {
-			log.Printf("Disk %d size not set, using default '20G'", idx)
-			c.Disks[idx].Size = "20G"
-		}
-		if c.Disks[idx].CacheMode == "" {
-			log.Printf("Disk %d cache mode not set, using default 'none'", idx)
-			c.Disks[idx].CacheMode = "none"
-		}
-		if c.Disks[idx].IOThread {
-			// io thread is only supported by virtio-scsi-single controller
-			if c.SCSIController != "virtio-scsi-single" {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("io thread option requires virtio-scsi-single controller"))
-			} else {
-				// ... and only for virtio and scsi disks
-				if !(c.Disks[idx].Type == "scsi" || c.Disks[idx].Type == "virtio") {
-					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("io thread option requires scsi or a virtio disk"))
-				}
-			}
-		}
-		// For any storage pool types which aren't in rxStorageTypes in proxmox-api/proxmox/config_qemu.go:890
-		// (currently zfspool|lvm|rbd|cephfs), the format parameter is mandatory. Make sure this is still up to date
-		// when updating the vendored code!
-		if !contains([]string{"zfspool", "lvm", "rbd", "cephfs"}, c.Disks[idx].StoragePoolType) && c.Disks[idx].DiskFormat == "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disk format must be specified for pool type %q", c.Disks[idx].StoragePoolType))
-		}
-	}
-	if c.SCSIController == "" {
-		log.Printf("SCSI controller not set, using default 'lsi'")
-		c.SCSIController = "lsi"
-	}
-
-	errs = packersdk.MultiErrorAppend(errs, c.Comm.Prepare(&c.Ctx)...)
-	errs = packersdk.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.Ctx)...)
-	errs = packersdk.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.Ctx)...)
-
-	// Required configurations that will display errors if not set
-	if c.Username == "" {
-		errs = packersdk.MultiErrorAppend(errs, errors.New("username must be specified"))
-	}
-	if c.Password == "" && c.Token == "" {
-		errs = packersdk.MultiErrorAppend(errs, errors.New("password or token must be specified"))
-	}
-	if c.ProxmoxURLRaw == "" {
-		errs = packersdk.MultiErrorAppend(errs, errors.New("proxmox_url must be specified"))
-	}
-	if c.proxmoxURL, err = url.Parse(c.ProxmoxURLRaw); err != nil {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Could not parse proxmox_url: %s", err))
-	}
-	if c.Node == "" {
-		errs = packersdk.MultiErrorAppend(errs, errors.New("node must be specified"))
-	}
-	
-	// Verify VM Name and Template Name are a valid DNS Names
-	re := regexp.MustCompile(`^(?:(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?)\.)*(?:[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?))$`)
-	if !re.MatchString(c.VMName) {
-			errs = packersdk.MultiErrorAppend(errs, errors.New("vm_name must be a valid DNS name"))
-	}
-	if !re.MatchString(c.TemplateName) {
-			errs = packersdk.MultiErrorAppend(errs, errors.New("template_name must be a valid DNS name"))
-	}
-	for idx := range c.NICs {
-		if c.NICs[idx].Bridge == "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("network_adapters[%d].bridge must be specified", idx))
-		}
-		if c.NICs[idx].Model != "virtio" && c.NICs[idx].PacketQueues > 0 {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("network_adapters[%d].packet_queues can only be set for 'virtio' driver", idx))
-		}
-	}
-	for idx := range c.Disks {
-		if c.Disks[idx].StoragePool == "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disks[%d].storage_pool must be specified", idx))
-		}
-		if c.Disks[idx].StoragePoolType == "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disks[%d].storage_pool_type must be specified", idx))
-		}
-	}
-	for idx := range c.AdditionalISOFiles {
-		// Check AdditionalISO config
-		// Either a pre-uploaded ISO should be referenced in iso_file, OR a URL
-		// (possibly to a local file) to an ISO file that will be downloaded and
-		// then uploaded to Proxmox.
-		if c.AdditionalISOFiles[idx].ISOFile != "" {
-			c.AdditionalISOFiles[idx].ShouldUploadISO = false
-		} else {
-			c.AdditionalISOFiles[idx].DownloadPathKey = "downloaded_additional_iso_path_" + strconv.Itoa(idx)
-			isoWarnings, isoErrors := c.AdditionalISOFiles[idx].ISOConfig.Prepare(&c.Ctx)
-			errs = packersdk.MultiErrorAppend(errs, isoErrors...)
-			warnings = append(warnings, isoWarnings...)
-			c.AdditionalISOFiles[idx].ShouldUploadISO = true
-		}
-		if c.AdditionalISOFiles[idx].Device == "" {
-			log.Printf("AdditionalISOFile %d Device not set, using default 'ide3'", idx)
-			c.AdditionalISOFiles[idx].Device = "ide3"
-		}
-		if strings.HasPrefix(c.AdditionalISOFiles[idx].Device, "ide") {
-			busnumber, err := strconv.Atoi(c.AdditionalISOFiles[idx].Device[3:])
-			if err != nil {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("%s is not a valid bus index", c.AdditionalISOFiles[idx].Device[3:]))
-			}
-			if busnumber == 2 {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("IDE bus 2 is used by boot ISO"))
-			}
-			if busnumber > 3 {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("IDE bus index can't be higher than 3"))
-			}
-		}
-		if strings.HasPrefix(c.AdditionalISOFiles[idx].Device, "sata") {
-			busnumber, err := strconv.Atoi(c.AdditionalISOFiles[idx].Device[4:])
-			if err != nil {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("%s is not a valid bus index", c.AdditionalISOFiles[idx].Device[4:]))
-			}
-			if busnumber > 5 {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("SATA bus index can't be higher than 5"))
-			}
-		}
-		if strings.HasPrefix(c.AdditionalISOFiles[idx].Device, "scsi") {
-			busnumber, err := strconv.Atoi(c.AdditionalISOFiles[idx].Device[4:])
-			if err != nil {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("%s is not a valid bus index", c.AdditionalISOFiles[idx].Device[4:]))
-			}
-			if busnumber > 30 {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("SCSI bus index can't be higher than 30"))
-			}
-		}
-		if (c.AdditionalISOFiles[idx].ISOFile == "" && len(c.AdditionalISOFiles[idx].ISOConfig.ISOUrls) == 0) || (c.AdditionalISOFiles[idx].ISOFile != "" && len(c.AdditionalISOFiles[idx].ISOConfig.ISOUrls) != 0) {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("either iso_file or iso_url, but not both, must be specified for AdditionalISO file %s", c.AdditionalISOFiles[idx].Device))
-		}
-	}
-
-	if errs != nil && len(errs.Errors) > 0 {
-		return nil, warnings, errs
-	}
-	return nil, warnings, nil
 }
 
-func contains(haystack []string, needle string) bool {
-	for _, candidate := range haystack {
-		if candidate == needle {
-			return true
+func TestPacketQueueSupportForNetworkAdapters(t *testing.T) {
+	drivertests := []struct {
+		expectedToFail bool
+		model          string
+	}{
+		{expectedToFail: false, model: "virtio"},
+		{expectedToFail: true, model: "e1000"},
+		{expectedToFail: true, model: "e1000-82540em"},
+		{expectedToFail: true, model: "e1000-82544gc"},
+		{expectedToFail: true, model: "e1000-82545em"},
+		{expectedToFail: true, model: "i82551"},
+		{expectedToFail: true, model: "i82557b"},
+		{expectedToFail: true, model: "i82559er"},
+		{expectedToFail: true, model: "ne2k_isa"},
+		{expectedToFail: true, model: "ne2k_pci"},
+		{expectedToFail: true, model: "pcnet"},
+		{expectedToFail: true, model: "rtl8139"},
+		{expectedToFail: true, model: "vmxnet3"},
+	}
+
+	for _, tt := range drivertests {
+		device := make(map[string]interface{})
+		device["bridge"] = "vmbr0"
+		device["model"] = tt.model
+		device["packet_queues"] = 2
+
+		devices := make([]map[string]interface{}, 0)
+		devices = append(devices, device)
+
+		cfg := mandatoryConfig(t)
+		cfg["network_adapters"] = devices
+
+		var c Config
+		_, _, err := c.Prepare(&c, cfg)
+
+		if tt.expectedToFail == true && err == nil {
+			t.Error("expected config preparation to fail, but no error occured")
+		}
+
+		if tt.expectedToFail == false && err != nil {
+			t.Errorf("expected config preparation to succeed, but %s", err.Error())
 		}
 	}
-	return false
+}
+
+func TestVMandTemplateName(t *testing.T) {
+	dnsnametests := []struct {
+		expectedToFail bool
+		name          string
+	}{
+		{expectedToFail: false, name: "packer"},
+		{expectedToFail: false, name: "pac.ker"},
+		{expectedToFail: true, name: "pac_ker"},
+		{expectedToFail: true, name: "pac ker"},
+	}
+
+	for _, tt := range dnsnametests {
+
+		cfg := mandatoryConfig(t)
+		cfg["vm_name"] = tt.name
+		cfg["template_name"] = tt.name
+
+		var c Config
+		_, _, err := c.Prepare(&c, cfg)
+
+		if tt.expectedToFail == true && err == nil {
+			t.Error("expected config preparation to fail, but no error occured")
+		}
+
+		if tt.expectedToFail == false && err != nil {
+			t.Errorf("expected config preparation to succeed, but %s", err.Error())
+		}
+	}
 }

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -102,3 +102,33 @@ func TestPacketQueueSupportForNetworkAdapters(t *testing.T) {
 		}
 	}
 }
+
+func TestVMandTemplateName(t *testing.T) {
+	dnsnametests := []struct {
+		expectedToFail bool
+		name          string
+	}{
+		{expectedToFail: false, name: "packer"},
+		{expectedToFail: false, name: "pac.ker"},
+		{expectedToFail: true, name: "pac_ker"},
+		{expectedToFail: true, name: "pac ker"},
+	}
+
+	for _, tt := range dnsnametests {
+
+		cfg := mandatoryConfig(t)
+		cfg["vm_name"] = tt.name
+		cfg["template_name"] = tt.name
+
+		var c Config
+		_, _, err := c.Prepare(&c, cfg)
+
+		if tt.expectedToFail == true && err == nil {
+			t.Error("expected config preparation to fail, but no error occured")
+		}
+
+		if tt.expectedToFail == false && err != nil {
+			t.Errorf("expected config preparation to succeed, but %s", err.Error())
+		}
+	}
+}


### PR DESCRIPTION
### Proposed Change:
Validate vm_name and template name for the proxmox builder to ensure they meet the proxmox naming scheme. This uses the same regex that proxmox uses in its webui.

### Background:
In proxmox, the name of templates and virtual machines must be valid DNS names. This is validated in the proxmox webui here: https://git.proxmox.com/?p=proxmox-widget-toolkit.git;a=blob;f=src/Utils.js;hb=e2ecec942fa19505cbb53d4b8eba6f356ea35b88#l1148
![image](https://user-images.githubusercontent.com/68717336/117904939-4bbb2700-b2a0-11eb-93d8-5e49ed4d28b7.png)


A valid DNS name is defined here:
https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou#:~:text=DNS%20names%20can%20contain%20only,components%20of%20domain%20style%20names.


Closes #14 

