### PR TITLE
Fix `qemu_agent` to default to `true` when using HCL2

### DIFF
--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -53,8 +53,8 @@ func TestAgentSetToFalse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if c.Agent != false {
-		t.Errorf("Expected Agent to be false, got %t", c.Agent)
+	if c.Agent.False() != true {
+		t.Errorf("Expected Agent to be false, got %t", c.Agent.True())
 	}
 }
 
@@ -106,7 +106,7 @@ func TestPacketQueueSupportForNetworkAdapters(t *testing.T) {
 func TestVMandTemplateName(t *testing.T) {
 	dnsnametests := []struct {
 		expectedToFail bool
-		name          string
+		name           string
 	}{
 		{expectedToFail: false, name: "packer"},
 		{expectedToFail: false, name: "pac.ker"},

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -33,7 +33,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 	c := state.Get("config").(*Config)
 
 	agent := 1
-	if c.Agent == false {
+	if c.Agent.False() {
 		agent = 0
 	}
 

--- a/builder/proxmox/iso/config_test.go
+++ b/builder/proxmox/iso/config_test.go
@@ -97,8 +97,8 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)
 	}
-	if b.config.Agent != true {
-		t.Errorf("Expected Agent to be true, got %t", b.config.Agent)
+	if b.config.Agent.True() != true {
+		t.Errorf("Expected Agent to be true, got %t", b.config.Agent.True())
 	}
 	if b.config.DisableKVM != false {
 		t.Errorf("Expected Disable KVM toggle to be false, got %t", b.config.DisableKVM)
@@ -121,8 +121,8 @@ func TestAgentSetToFalse(t *testing.T) {
 		t.Fatal(err, warn)
 	}
 
-	if c.Agent != false {
-		t.Errorf("Expected Agent to be false, got %t", c.Agent)
+	if c.Agent.False() != true {
+		t.Errorf("Expected Agent to be false, got %t", c.Agent.True())
 	}
 }
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -213,7 +213,7 @@ builder.
 - `onboot` (boolean) - Specifies whether a VM will be started during system
   bootup. Defaults to `false`.
 
-- `qemu_agent` (boolean) - Disables QEMU Agent option for this VM. When enabled,
+- `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
   `ssh_host` should be used. Defaults to `true`.
 
@@ -221,7 +221,7 @@ builder.
 
 - `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
-  Defaults to `lsi`.
+  Defaults to `lsi`.f
 
 - `cloud_init` (bool) - If true, add a Cloud-Init CDROM drive after the virtual machine has been converted to a template.
   Defaults to `false`.
@@ -247,7 +247,7 @@ builder.
     `sataX` or `scsiX`.
     For `ide` the bus index ranges from 0 to 3, for `sata` form 0 to 5 and for
     `scsi` from 0 to 30.
-    Defaults to `ide3` since `ide2` is generelly the boot drive.
+    Defaults to `ide3` since `ide2` is generally the boot drive.
 
   - `iso_file` (string) - Path to the ISO file to boot from, expressed as a
     proxmox datastore path, for example


### PR DESCRIPTION
When using a `.pkr.hcl` file rather than a `.json`, the config is parsed twice for `.pkr.hcl` files, resulting in a nil value being provided to the `config.decode`, where a `.json` file doesn't have that parameter set. The `config.decode` interpolates this, returning `false` and ignores the context `c.Agent` being a default of `true`.

This issue came up previously on other plugins, and was resolved https://github.com/hashicorp/packer/pull/8021. However, it appears that the proxmox plugin was not included in this fix.

This PR applies that fix to the `qemu_agent` parameter.

Closes #16

Also fixed a couple of typos in the docs.

