### PR TITLE
proxmox-clone: choose template located on target node if possible

### DIFF
--- a/builder/proxmox/clone/builder.go
+++ b/builder/proxmox/clone/builder.go
@@ -58,10 +58,19 @@ func (*cloneVMCreator) Create(vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQ
 	config.FullClone = &fullClone
 	config.CIuser = comm.SSHUsername
 	config.Sshkeys = string(comm.SSHPublicKey)
-	sourceVmr, err := client.GetVmRefByName(c.CloneVM)
+	sourceVmrs, err := client.GetVmRefsByName(c.CloneVM)
 	if err != nil {
 		return err
 	}
+
+	// prefer source Vm located on same node
+	sourceVmr := sourceVmrs[0]
+	for _, candVmr := range sourceVmrs {
+		if candVmr.Node() == vmRef.Node() {
+			sourceVmr = candVmr
+		}
+	}
+
 	err = config.CloneVm(sourceVmr, vmRef, client)
 	if err != nil {
 		return err


### PR DESCRIPTION
In case of multiple templates with same name on multiple hosts, proxmox-clone chooses first template
returned by Proxmox. This commit forces it to choose template located on
target node if possible. It's helpful if templates use local storage and it's
impossible to clone templates between nodes, i.e. to avoid errors like:
"500 can't clone VM to node 'host2' (VM uses local storage)"
or
"500 storage 'xyz' is not available on node 'host1'"