### PR TITLE
Fix nav_title for clone builder documentation

### DIFF
--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -6,7 +6,7 @@ description: |
   launching it, then creates a virtual machine template.
 page_title: Proxmox Clone - Builders
 sidebar_title: proxmox-clone
-nav_title: ISO
+nav_title: Clone
 ---
 
 # Proxmox Builder (from an image)


### PR DESCRIPTION
On the left hand menu, both proxmox-clone and proxmox-iso appeared as "ISO"

![image](https://user-images.githubusercontent.com/17222/128093347-51247646-c1ec-4184-a058-b97117d34bf7.png)


