### PR TITLE
Allow user to specify task_timeout

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -85,6 +85,7 @@ type FlatConfig struct {
 	Token                     *string                            `mapstructure:"token" cty:"token" hcl:"token"`
 	Node                      *string                            `mapstructure:"node" cty:"node" hcl:"node"`
 	Pool                      *string                            `mapstructure:"pool" cty:"pool" hcl:"pool"`
+	TaskTimeout               *string                            `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
@@ -196,6 +197,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"node":                         &hcldec.AttrSpec{Name: "node", Type: cty.String, Required: false},
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
+		"task_timeout":                 &hcldec.AttrSpec{Name: "task_timeout", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},

--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -3,19 +3,16 @@ package proxmox
 import (
 	"crypto/tls"
 	"log"
-	"time"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
-
-const defaultTaskTimeout = 30 * time.Second
 
 func newProxmoxClient(config Config) (*proxmox.Client, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: config.SkipCertValidation,
 	}
 
-	client, err := proxmox.NewClient(config.proxmoxURL.String(), nil, tlsConfig, int(defaultTaskTimeout.Seconds()))
+	client, err := proxmox.NewClient(config.proxmoxURL.String(), nil, tlsConfig, int(config.TaskTimeout.Seconds()))
 	if err != nil {
 		return nil, err
 	}

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Token              string `mapstructure:"token"`
 	Node               string `mapstructure:"node"`
 	Pool               string `mapstructure:"pool"`
+	TaskTimeout        time.Duration `mapstructure:"task_timeout"`
 
 	VMName string `mapstructure:"vm_name"`
 	VMID   int    `mapstructure:"vm_id"`
@@ -142,6 +143,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	}
 	if c.Token == "" {
 		c.Token = os.Getenv("PROXMOX_TOKEN")
+	}
+	if c.TaskTimeout == 0 {
+		c.TaskTimeout = 60 * time.Second
 	}
 	if c.BootKeyInterval == 0 && os.Getenv(bootcommand.PackerKeyEnv) != "" {
 		var err error

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -84,6 +84,7 @@ type FlatConfig struct {
 	Token                     *string                    `mapstructure:"token" cty:"token" hcl:"token"`
 	Node                      *string                    `mapstructure:"node" cty:"node" hcl:"node"`
 	Pool                      *string                    `mapstructure:"pool" cty:"pool" hcl:"pool"`
+	TaskTimeout               *string                    `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                    `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                       `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Boot                      *string                    `mapstructure:"boot" cty:"boot" hcl:"boot"`
@@ -193,6 +194,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"node":                         &hcldec.AttrSpec{Name: "node", Type: cty.String, Required: false},
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
+		"task_timeout":                 &hcldec.AttrSpec{Name: "task_timeout", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -85,6 +85,7 @@ type FlatConfig struct {
 	Token                     *string                            `mapstructure:"token" cty:"token" hcl:"token"`
 	Node                      *string                            `mapstructure:"node" cty:"node" hcl:"node"`
 	Pool                      *string                            `mapstructure:"pool" cty:"pool" hcl:"pool"`
+	TaskTimeout               *string                            `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
@@ -202,6 +203,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"node":                         &hcldec.AttrSpec{Name: "node", Type: cty.String, Required: false},
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
+		"task_timeout":                 &hcldec.AttrSpec{Name: "task_timeout", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -16,6 +16,8 @@
 
 - `pool` (string) - Pool
 
+- `task_timeout` (duration string | ex: "1h5m2s") - Task Timeout
+
 - `vm_name` (string) - VM Name
 
 - `vm_id` (int) - VMID
@@ -38,7 +40,7 @@
 
 - `disks` ([]diskConfig) - Disks
 
-- `qemu_agent` (bool) - Agent
+- `qemu_agent` (boolean) - Agent
 
 - `scsi_controller` (string) - SCSI Controller
 

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -68,6 +68,9 @@ in the image's Cloud-Init settings for provisioning.
 
 - `insecure_skip_tls_verify` (bool) - Skip validating the certificate.
 
+- `task_timeout` (duration string | ex: "10m") - The timeout for
+  Promox API operations, e.g. clones. Defaults to 1 minute.
+
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
 - `vm_name` (string) - Name of the virtual machine during creation. If not


### PR DESCRIPTION
Closes #20 

The default timeout of 30 seconds is too slow for many proxmox setups. This changes the default to 60 seconds, as well as introduces a new builder argument called `task_timeout`, specified as a duration string.


