### PR TITLE
Reverse search order for ide disks for cloud-init allocation.

### DIFF
--- a/builder/proxmox/common/step_finalize_template_config.go
+++ b/builder/proxmox/common/step_finalize_template_config.go
@@ -55,7 +55,7 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 			}
 		}
 		if cloudInitStoragePool != "" {
-			ideControllers := []string{"ide3", "ide2", "ide1", "ide0"}
+			ideControllers := []string{"ide0", "ide1", "ide2", "ide3"}
 			cloudInitAttached := false
 			// find a free ide controller
 			for _, controller := range ideControllers {

--- a/builder/proxmox/common/step_finalize_template_config_test.go
+++ b/builder/proxmox/common/step_finalize_template_config_test.go
@@ -85,7 +85,7 @@ func TestTemplateFinalize(t *testing.T) {
 			expectedVMConfig: map[string]interface{}{
 				"name":        "my-template",
 				"description": "some-description",
-				"ide3":        "ceph01:cloudinit",
+				"ide0":        "ceph01:cloudinit",
 			},
 			expectedAction: multistep.ActionContinue,
 		},


### PR DESCRIPTION
Reverses the order of the cloud-init ide drive selection to start at low numbers instead of starting at high numbers.

This solves an issue where when building an image with cloud-init enabled, proxmox reports the following:
```
generating cloud-init ISO
kvm: -device ide-cd,bus=ide.1,unit=1,drive=drive-ide3,id=ide3: Can't create IDE unit 1, bus supports only 1 units
TASK ERROR: start failed: QEMU exited with code 1
```

Closes Plugin assigns bad ide drive to cloud-init #55

Can be **tested** by cloning: https://github.com/VoightCloud/CopperCentos7.git

Modify **username** to your proxmox packer username, modify **token** to your proxmox token, modify **node** to your node, modify **proxmox_url** to your proxmox_url, upload **Centos-7-x86_64-Everything-2009.iso** to your local:iso/ storage.

cd into packer directory and type `./build.sh`
