### PR TITLE
Documentation: Fix key of http_content

### DIFF
--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -476,7 +476,7 @@ Example usage from a builder:
   default this is empty, which means no HTTP server will be started. The
   address and port of the HTTP server will be available as variables in
   `boot_command`. This is covered in more detail below. Example: Setting
-  `"foo/bar"="baz"`, will allow you to http get on
+  `"/foo/bar"="baz"`, will allow you to http get on
   `http://{http_ip}:{http_port}/foo/bar`.
 
 - `http_port_min` (int) - These are the minimum and maximum port to use for the HTTP server


### PR DESCRIPTION
The documentation for `http_content` is wrong: the key of the map must start with a slash.

