### PR TITLE
Use VM name when template name not provided

### DIFF
--- a/builder/proxmox/common/step_finalize_template_config.go
+++ b/builder/proxmox/common/step_finalize_template_config.go
@@ -30,6 +30,7 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 
 	changes := make(map[string]interface{})
 
+	changes["name"] = c.VMName
 	if c.TemplateName != "" {
 		changes["name"] = c.TemplateName
 	}

--- a/builder/proxmox/common/step_finalize_template_config_test.go
+++ b/builder/proxmox/common/step_finalize_template_config_test.go
@@ -36,7 +36,7 @@ func TestTemplateFinalize(t *testing.T) {
 		expectedAction      multistep.StepAction
 	}{
 		{
-			name:          "empty config changes only description",
+			name:          "empty config changes name and description",
 			builderConfig: &Config{},
 			initialVMConfig: map[string]interface{}{
 				"name":        "dummy",
@@ -45,9 +45,38 @@ func TestTemplateFinalize(t *testing.T) {
 			},
 			expectCallSetConfig: true,
 			expectedVMConfig: map[string]interface{}{
-				"name":        nil,
+				"name":        "",
 				"description": "",
 				"ide2":        nil,
+			},
+			expectedAction: multistep.ActionContinue,
+		},
+		{
+			name: "use VM name when template name not provided",
+			builderConfig: &Config{
+				VMName: "my-vm",
+			},
+			initialVMConfig: map[string]interface{}{
+				"name": "dummy",
+			},
+			expectCallSetConfig: true,
+			expectedVMConfig: map[string]interface{}{
+				"name": "my-vm",
+			},
+			expectedAction: multistep.ActionContinue,
+		},
+		{
+			name: "use template name when both VM name and template name are provided",
+			builderConfig: &Config{
+				VMName:       "my-vm",
+				TemplateName: "my-template",
+			},
+			initialVMConfig: map[string]interface{}{
+				"name": "dummy",
+			},
+			expectCallSetConfig: true,
+			expectedVMConfig: map[string]interface{}{
+				"name": "my-template",
 			},
 			expectedAction: multistep.ActionContinue,
 		},


### PR DESCRIPTION
The Proxmox Packer plugin documentation states this:

> template_name (string) - Name of the template. Defaults to the generated name used during creation.

However, during testing, when the `template_name` option is not provided the following error occurs:

```
==> centos.proxmox-iso.centos: Error updating template: 500 no options specified
```

These changes default to using the `VMName` from the configuration, layering in the user provided `template_name` when it exists.
