### PR TITLE
[Issue 71] Adds convert_to_template option to proxmox builders

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -106,6 +106,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                              `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                            `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                            `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
+	ConvertToTemplate         *bool                              `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
 	CloudInit                 *bool                              `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
@@ -221,6 +222,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
+		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -106,7 +106,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                              `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                            `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                            `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
-	ConvertToTemplate         *bool                              `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
+	SkipConvertToTemplate     *bool                              `mapstructure:"skip_convert_to_template" cty:"skip_convert_to_template" hcl:"skip_convert_to_template"`
 	CloudInit                 *bool                              `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
@@ -222,7 +222,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
-		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
+		"skip_convert_to_template":     &hcldec.AttrSpec{Name: "skip_convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},

--- a/builder/proxmox/common/artifact.go
+++ b/builder/proxmox/common/artifact.go
@@ -11,7 +11,8 @@ import (
 
 type Artifact struct {
 	builderID     string
-	templateID    int
+	vmID          int
+	isTemplate    bool
 	proxmoxClient *proxmox.Client
 
 	// StateData should store data such as GeneratedData
@@ -31,11 +32,15 @@ func (*Artifact) Files() []string {
 }
 
 func (a *Artifact) Id() string {
-	return strconv.Itoa(a.templateID)
+	return strconv.Itoa(a.vmID)
 }
 
 func (a *Artifact) String() string {
-	return fmt.Sprintf("A template was created: %d", a.templateID)
+
+	if a.isTemplate {
+		return fmt.Sprintf("A Template was created: %d", a.vmID)
+	}
+	return fmt.Sprintf("A VM was created: %d", a.vmID)
 }
 
 func (a *Artifact) State(name string) interface{} {
@@ -43,7 +48,12 @@ func (a *Artifact) State(name string) interface{} {
 }
 
 func (a *Artifact) Destroy() error {
-	log.Printf("Destroying template: %d", a.templateID)
-	_, err := a.proxmoxClient.DeleteVm(proxmox.NewVmRef(a.templateID))
+
+	if a.isTemplate {
+		log.Printf("Destroying Template: %d", a.vmID)
+	} else {
+		log.Printf("Destroying VM: %d", a.vmID)
+	}
+	_, err := a.proxmoxClient.DeleteVm(proxmox.NewVmRef(a.vmID))
 	return err
 }

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -67,9 +67,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook,
 	})
 	coreSteps = append(coreSteps, &stepStopVM{})
 
-	if b.config.ConvertToTemplate {
-		coreSteps = append(coreSteps, &stepConvertToTemplate{})
-	}
+	coreSteps = append(coreSteps, &stepConvertToTemplate{})
 
 	coreSteps = append(coreSteps, &stepFinalizeVMConfig{})
 	coreSteps = append(coreSteps, &stepSuccess{})

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -108,7 +108,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook,
 	artifact := &Artifact{
 		builderID:     b.id,
 		vmID:          vmRef.VmId(),
-		isTemplate:    b.config.ConvertToTemplate,
+		isTemplate:    !b.config.SkipConvertToTemplate.True(),
 		proxmoxClient: b.proxmoxClient,
 		StateData:     map[string]interface{}{"generated_data": state.Get("generated_data")},
 	}

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -64,6 +64,7 @@ type Config struct {
 
 	TemplateName        string `mapstructure:"template_name"`
 	TemplateDescription string `mapstructure:"template_description"`
+	ConvertToTemplate   bool   `mapstructure:"convert_to_template"`
 
 	CloudInit            bool   `mapstructure:"cloud_init"`
 	CloudInitStoragePool string `mapstructure:"cloud_init_storage_pool"`
@@ -109,6 +110,9 @@ type vgaConfig struct {
 func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []string, error) {
 	// Do not add a cloud-init cdrom by default
 	c.CloudInit = false
+	// Do not covert vm to a template by default
+	c.ConvertToTemplate = false
+
 	var md mapstructure.Metadata
 	err := config.Decode(upper, &config.DecodeOpts{
 		Metadata:           &md,

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -62,9 +62,9 @@ type Config struct {
 	Onboot         bool           `mapstructure:"onboot"`
 	DisableKVM     bool           `mapstructure:"disable_kvm"`
 
-	TemplateName        string `mapstructure:"template_name"`
-	TemplateDescription string `mapstructure:"template_description"`
-	ConvertToTemplate   bool   `mapstructure:"convert_to_template"`
+	TemplateName          string         `mapstructure:"template_name"`
+	TemplateDescription   string         `mapstructure:"template_description"`
+	SkipConvertToTemplate config.Trilean `mapstructure:"skip_convert_to_template"`
 
 	CloudInit            bool   `mapstructure:"cloud_init"`
 	CloudInitStoragePool string `mapstructure:"cloud_init_storage_pool"`
@@ -110,8 +110,6 @@ type vgaConfig struct {
 func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []string, error) {
 	// Do not add a cloud-init cdrom by default
 	c.CloudInit = false
-	// Do not covert vm to a template by default
-	c.ConvertToTemplate = false
 
 	var md mapstructure.Metadata
 	err := config.Decode(upper, &config.DecodeOpts{

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -105,7 +105,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                      `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                    `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                    `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
-	ConvertToTemplate         *bool                      `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
+	SkipConvertToTemplate     *bool                      `mapstructure:"skip_convert_to_template" cty:"skip_convert_to_template" hcl:"skip_convert_to_template"`
 	CloudInit                 *bool                      `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                    `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
@@ -219,7 +219,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
-		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
+		"skip_convert_to_template":     &hcldec.AttrSpec{Name: "skip_convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*FlatadditionalISOsConfig)(nil).HCL2Spec())},

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -105,6 +105,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                      `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                    `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                    `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
+	ConvertToTemplate         *bool                      `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
 	CloudInit                 *bool                      `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                    `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
@@ -218,6 +219,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
+		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*FlatadditionalISOsConfig)(nil).HCL2Spec())},

--- a/builder/proxmox/common/step_convert_to_template.go
+++ b/builder/proxmox/common/step_convert_to_template.go
@@ -23,14 +23,21 @@ func (s *stepConvertToTemplate) Run(ctx context.Context, state multistep.StateBa
 	ui := state.Get("ui").(packersdk.Ui)
 	client := state.Get("proxmoxClient").(templateConverter)
 	vmRef := state.Get("vmRef").(*proxmox.VmRef)
+	c := state.Get("config").(*Config)
 
-	ui.Say("Converting VM to template")
-	var err = client.CreateTemplate(vmRef)
-	if err != nil {
-		err := fmt.Errorf("Error converting VM to template: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
+	if c.ConvertToTemplate {
+
+		ui.Say("Converting VM to template")
+		var err = client.CreateTemplate(vmRef)
+		if err != nil {
+			err := fmt.Errorf("Error converting VM to template: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+	} else {
+		ui.Say("Skipping VM template conversion")
 	}
 
 	return multistep.ActionContinue

--- a/builder/proxmox/common/step_convert_to_template.go
+++ b/builder/proxmox/common/step_convert_to_template.go
@@ -25,12 +25,12 @@ func (s *stepConvertToTemplate) Run(ctx context.Context, state multistep.StateBa
 	vmRef := state.Get("vmRef").(*proxmox.VmRef)
 	c := state.Get("config").(*Config)
 
-	if c.ConvertToTemplate {
+	if !c.SkipConvertToTemplate.True() {
 
 		ui.Say("Converting VM to template")
 		var err = client.CreateTemplate(vmRef)
 		if err != nil {
-			err := fmt.Errorf("Error converting VM to template: %s", err)
+			err := fmt.Errorf("error converting VM to template: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt

--- a/builder/proxmox/common/step_finalize_vm_config.go
+++ b/builder/proxmox/common/step_finalize_vm_config.go
@@ -10,10 +10,10 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-// stepFinalizeTemplateConfig does any required modifications to the configuration _after_
+// stepFinalizeVMConfig does any required modifications to the configuration _after_
 // the VM has been converted into a template, such as updating name and description, or
 // unmounting the installation ISO.
-type stepFinalizeTemplateConfig struct{}
+type stepFinalizeVMConfig struct{}
 
 type templateFinalizer interface {
 	GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error)
@@ -22,7 +22,7 @@ type templateFinalizer interface {
 
 var _ templateFinalizer = &proxmox.Client{}
 
-func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepFinalizeVMConfig) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	client := state.Get("proxmoxClient").(templateFinalizer)
 	c := state.Get("config").(*Config)
@@ -118,4 +118,4 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 	return multistep.ActionContinue
 }
 
-func (s *stepFinalizeTemplateConfig) Cleanup(state multistep.StateBag) {}
+func (s *stepFinalizeVMConfig) Cleanup(state multistep.StateBag) {}

--- a/builder/proxmox/common/step_finalize_vm_config_test.go
+++ b/builder/proxmox/common/step_finalize_vm_config_test.go
@@ -191,7 +191,7 @@ func TestTemplateFinalize(t *testing.T) {
 			state.Put("vmRef", proxmox.NewVmRef(1))
 			state.Put("proxmoxClient", finalizer)
 
-			step := stepFinalizeTemplateConfig{}
+			step := stepFinalizeVMConfig{}
 			action := step.Run(context.TODO(), state)
 			if action != c.expectedAction {
 				t.Errorf("Expected action to be %v, got %v", c.expectedAction, action)

--- a/builder/proxmox/common/step_stop_vm.go
+++ b/builder/proxmox/common/step_stop_vm.go
@@ -9,7 +9,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-// stepStopVM takes the running VM configured in earlier steps ands stops it.
+// stepStopVM takes the running VM configured in earlier steps and stops it.
 
 type stepStopVM struct{}
 

--- a/builder/proxmox/common/step_stop_vm.go
+++ b/builder/proxmox/common/step_stop_vm.go
@@ -1,0 +1,39 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// stepStopVM takes the running VM configured in earlier steps ands stops it.
+
+type stepStopVM struct{}
+
+type vmTerminator interface {
+	ShutdownVm(*proxmox.VmRef) (string, error)
+}
+
+var _ templateConverter = &proxmox.Client{}
+
+func (s *stepStopVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packersdk.Ui)
+	client := state.Get("proxmoxClient").(vmTerminator)
+	vmRef := state.Get("vmRef").(*proxmox.VmRef)
+
+	ui.Say("Stopping VM")
+	_, err := client.ShutdownVm(vmRef)
+	if err != nil {
+		err := fmt.Errorf("Error converting VM to template, could not stop: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepStopVM) Cleanup(state multistep.StateBag) {}

--- a/builder/proxmox/common/step_stop_vm_test.go
+++ b/builder/proxmox/common/step_stop_vm_test.go
@@ -1,0 +1,71 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type vmTerminatorMock struct {
+	shutdownVm func(*proxmox.VmRef) (string, error)
+}
+
+func (m vmTerminatorMock) ShutdownVm(r *proxmox.VmRef) (string, error) {
+	return m.shutdownVm(r)
+}
+
+var _ vmTerminator = vmTerminatorMock{}
+
+func TestStopVM(t *testing.T) {
+	cs := []struct {
+		name                 string
+		shutdownErr          error
+		expectCallShutdownVm bool
+		expectedAction       multistep.StepAction
+	}{
+		{
+			name:                 "NoError",
+			expectCallShutdownVm: true,
+			expectedAction:       multistep.ActionContinue,
+		},
+		{
+			name:                 "RaiseShutdownVMError",
+			expectCallShutdownVm: true,
+			shutdownErr:          fmt.Errorf("failed to stop vm"),
+			expectedAction:       multistep.ActionHalt,
+		},
+	}
+
+	const vmid = 123
+
+	for _, c := range cs {
+		t.Run(c.name, func(t *testing.T) {
+			terminator := vmTerminatorMock{
+				shutdownVm: func(r *proxmox.VmRef) (string, error) {
+					if r.VmId() != vmid {
+						t.Errorf("ShutdownVm called with unexpected id, expected %d, got %d", vmid, r.VmId())
+					}
+					if !c.expectCallShutdownVm {
+						t.Error("Did not expect ShutdownVM to be called")
+					}
+					return "", c.shutdownErr
+				},
+			}
+
+			state := new(multistep.BasicStateBag)
+			state.Put("ui", packersdk.TestUi(t))
+			state.Put("vmRef", proxmox.NewVmRef(vmid))
+			state.Put("proxmoxClient", terminator)
+
+			step := stepStopVM{}
+			action := step.Run(context.TODO(), state)
+			if action != c.expectedAction {
+				t.Errorf("Expected action to be %v, got %v", c.expectedAction, action)
+			}
+		})
+	}
+}

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -106,6 +106,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                              `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                            `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                            `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
+	ConvertToTemplate         *bool                              `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
 	CloudInit                 *bool                              `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
@@ -227,6 +228,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
+		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -106,7 +106,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                              `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                            `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                            `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
-	ConvertToTemplate         *bool                              `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
+	SkipConvertToTemplate     *bool                              `mapstructure:"skip_convert_to_template" cty:"skip_convert_to_template" hcl:"skip_convert_to_template"`
 	CloudInit                 *bool                              `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
@@ -228,7 +228,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
-		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
+		"skip_convert_to_template":     &hcldec.AttrSpec{Name: "skip_convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},

--- a/builder/proxmox/iso/config_test.go
+++ b/builder/proxmox/iso/config_test.go
@@ -42,11 +42,12 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
       "ssh_username": "root",
       "ssh_timeout": "15m",
       "ssh_password": "packer",
-
+	
       "unmount_iso": true,
       "template_name": "fedora-29",
-      "template_description": "Fedora 29-1.2, generated on {{ isotime \"2006-01-02T15:04:05Z\" }}"
-    }
+      "template_description": "Fedora 29-1.2, generated on {{ isotime \"2006-01-02T15:04:05Z\" }}",
+	  "convert_to_template": true
+	}
   ]
 }`
 	tpl, err := template.Parse(strings.NewReader(config))
@@ -108,6 +109,9 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	}
 	if b.config.CloudInit != false {
 		t.Errorf("Expected CloudInit to be false, got %t", b.config.CloudInit)
+	}
+	if b.config.ConvertToTemplate != true {
+		t.Errorf("Expected ConvertToTemplate to be true, got %t", b.config.CloudInit)
 	}
 }
 

--- a/builder/proxmox/iso/config_test.go
+++ b/builder/proxmox/iso/config_test.go
@@ -46,7 +46,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
       "unmount_iso": true,
       "template_name": "fedora-29",
       "template_description": "Fedora 29-1.2, generated on {{ isotime \"2006-01-02T15:04:05Z\" }}",
-	  "convert_to_template": true
+	  "skip_convert_to_template": true
 	}
   ]
 }`
@@ -110,8 +110,8 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	if b.config.CloudInit != false {
 		t.Errorf("Expected CloudInit to be false, got %t", b.config.CloudInit)
 	}
-	if b.config.ConvertToTemplate != true {
-		t.Errorf("Expected ConvertToTemplate to be true, got %t", b.config.CloudInit)
+	if b.config.SkipConvertToTemplate.False() {
+		t.Errorf("Expected ConvertToTemplate to be true, got %t", b.config.SkipConvertToTemplate.True())
 	}
 }
 

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -58,6 +58,8 @@
 
 - `template_description` (string) - Template Description
 
+- `convert_to_template` (bool) - Convert To Template
+
 - `cloud_init` (bool) - Cloud Init
 
 - `cloud_init_storage_pool` (string) - Cloud Init Storage Pool

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -58,7 +58,7 @@
 
 - `template_description` (string) - Template Description
 
-- `convert_to_template` (bool) - Convert To Template
+- `skip_convert_to_template` (bool) - Skips VM template conversion.
 
 - `cloud_init` (bool) - Cloud Init
 

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -192,7 +192,7 @@ in the image's Cloud-Init settings for provisioning.
 - `template_description` (string) - Description of the template, visible in
   the Proxmox interface.
 
-- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
+- `skip_convert_to_template` (bool) - Skips VM template conversion. Defaults to `false`.
 
 - `onboot` (boolean) - Specifies whether a VM will be started during system
   bootup. Defaults to `false`.

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -3,7 +3,7 @@ description: |
   The proxmox image Packer builder is able to create new images for use with
   Proxmox VE. The builder takes a cloud-init enabled virtual machine
   template name, runs any provisioning necessary on the image after
-  launching it, then creates a virtual machine template.
+  launching it, and creates a virtual machine or virtual machine template.
 page_title: Proxmox Clone - Builders
 sidebar_title: proxmox-clone
 nav_title: Clone
@@ -17,17 +17,15 @@ Artifact BuilderId: `proxmox.clone`
 The `proxmox-clone` Packer builder is able to create new images for use with
 [Proxmox](https://www.proxmox.com/en/proxmox-ve). The builder takes a virtual
 machine template, runs any provisioning necessary on the image after launching it,
-then creates a virtual machine template. This template can then be used as to
-create new virtual machines within Proxmox.
+and creates a virtual machine or virtual machine template.
 
-The builder does _not_ manage templates. Once it creates a template, it is up
+The builder does _not_ manage templates. It only creates a VM or VM template, it is up
 to you to use it or delete it.
 
 ## Configuration Reference
 
 There are many configuration options available for the builder. They are
-segmented below into two categories: required and optional parameters. Within
-each category, the available configuration keys are alphabetized.
+segmented below into two categories: required and optional parameters.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
@@ -193,6 +191,8 @@ in the image's Cloud-Init settings for provisioning.
 
 - `template_description` (string) - Description of the template, visible in
   the Proxmox interface.
+
+- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
 
 - `onboot` (boolean) - Specifies whether a VM will be started during system
   bootup. Defaults to `false`.

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -17,10 +17,10 @@ Packer is able to target both ISO and existing Cloud-Init images:
 - [proxmox-clone](/docs/builders/proxmox/clone) - The proxmox image
   Packer builder is able to create new images for use with Proxmox VE. The
   builder takes a cloud-init enabled virtual machine template name, runs any
-  provisioning necessary on the image after launching it, then creates a virtual
-  machine template.
+  provisioning necessary on the image after launching it, and creates a virtual
+  machine or virtual machine template.
 
 - [proxmox-iso](/docs/builders/proxmox/iso) - The proxmox Packer
   builder is able to create new images for use with Proxmox VE. The builder
   takes an ISO source, runs any provisioning necessary on the image after
-  launching it, then creates a virtual machine template.
+  launching it, and creates a virtual machine or virtual machine template.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -205,7 +205,7 @@ builder.
 - `template_description` (string) - Description of the template, visible in
   the Proxmox interface.
 
-- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
+- `skip_convert_to_template` (bool) - Skips VM template conversion. Defaults to `false`.
 
 - `unmount_iso` (bool) - If true, remove the mounted ISO from the template
   after finishing. Defaults to `false`.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -2,8 +2,7 @@
 description: |
   The proxmox Packer builder is able to create new images for use with
   Proxmox VE. The builder takes an ISO source, runs any provisioning
-  necessary on the image after launching it, then creates a virtual machine
-  template.
+  necessary on the image after launching it, and creates a virtual machine or virtual machine template.
 page_title: Proxmox ISO - Builders
 sidebar_title: proxmox-iso
 nav_title: ISO
@@ -16,18 +15,16 @@ Artifact BuilderId: `proxmox.iso`
 
 The `proxmox-iso` Packer builder is able to create new images for use with
 [Proxmox](https://www.proxmox.com/en/proxmox-ve). The builder takes an ISO
-image, runs any provisioning necessary on the image after launching it, then
-creates a virtual machine template. This template can then be used as to
-create new virtual machines within Proxmox.
+image, runs any provisioning necessary on the image after launching it, and
+creates a virtual machine or virtual machine template.
 
-The builder does _not_ manage templates. Once it creates a template, it is up
+The builder does _not_ manage templates. It only creates a VM or VM template, it is up
 to you to use it or delete it.
 
 ## Configuration Reference
 
 There are many configuration options available for the builder. They are
-segmented below into two categories: required and optional parameters. Within
-each category, the available configuration keys are alphabetized.
+segmented below into two categories: required and optional parameters.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
@@ -207,6 +204,8 @@ builder.
 
 - `template_description` (string) - Description of the template, visible in
   the Proxmox interface.
+
+- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
 
 - `unmount_iso` (bool) - If true, remove the mounted ISO from the template
   after finishing. Defaults to `false`.


### PR DESCRIPTION
Adds `convert_to_template` bool option to proxmox-iso and proxmox-clone builders configuration. 
This gives the user more control over the machine image, whether it stays a VM or is converted to a VM Template. 
The `convert_to_template` option is optional, and the default value is `false`, resulting in the VM not being converted to a template.
In practice the option is only need if the user wants the machine image to become a VM Template.

Tests:
Given working proxmox-iso and proxmox-clone packer file configurations, the following values were changed and run for each builder:

```
convert_to_template      = true  // result: vm is a template
convert_to_template      = false // result: vm is not a template 
remove convert_to_template option, testing default value // result: vm is not a template
```

Closes #71 

