### PR TITLE
[fix] packer ignores pool parameter

### DIFF
--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -87,6 +87,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		vmRef.SetNode(c.Node)
 		if c.Pool != "" {
 			vmRef.SetPool(c.Pool)
+			config.Pool = c.Pool
 		}
 
 		err := s.vmCreator.Create(vmRef, config, state)


### PR DESCRIPTION
The plugin ignores "pool" parameter due to incorrect copying of parameter value
into ConfigQemu. For example, in case of clone-vm for pooled template it results
into excluding of VM from pool.

This patch set "pool" parameter of ConfigQemu if parameter is not empty.

