### PR TITLE
[debug] show REST API calls if packer is executed with "-debug" option

### DIFF
--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -17,6 +17,8 @@ func newProxmoxClient(config Config) (*proxmox.Client, error) {
 		return nil, err
 	}
 
+	*proxmox.Debug = config.PackerDebug
+
 	if config.Token != "" {
 		// configure token auth
 		log.Print("using token auth")


### PR DESCRIPTION
This patch allows to trace all REST API calls if packer is executed with "-debug"
option. Before this patch, there is no way to enable such tracing. It simplifies
analysis of packer-proxmox interaction and identify root cause of breaks.
