### PR TITLE
Change to code to unmount cdrom due to change in proxmox format

### DIFF
--- a/builder/proxmox/iso/step_finalize_iso.go
+++ b/builder/proxmox/iso/step_finalize_iso.go
@@ -38,7 +38,7 @@ func (s *stepFinalizeISOTemplate) Run(ctx context.Context, state multistep.State
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
-		if vmParams["ide2"] == nil || !strings.HasSuffix(vmParams["ide2"].(string), "media=cdrom") {
+		if vmParams["ide2"] == nil || !strings.Contains(vmParams["ide2"].(string), "media=cdrom") {
 			err := fmt.Errorf("Cannot eject ISO from cdrom drive, ide2 is not present, or not a cdrom media")
 			state.Put("error", err)
 			ui.Error(err.Error())


### PR DESCRIPTION
Proxmox has changed the config format of the cdrom and HasSuffix won't work anymore, changed to Contains to allow the string "media=cdrom" to be anywhere in the response.

Closes #83 

