### PR TITLE
Update index.mdx

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -14,13 +14,13 @@ as new Proxmox Virtual Machine images.
 
 Packer is able to target both ISO and existing Cloud-Init images:
 
-- [proxmox-clone](/docs/builders/proxmox/clone) - The proxmox image
+- [proxmox-clone](/packer/plugins/builders/proxmox/clone) - The proxmox image
   Packer builder is able to create new images for use with Proxmox VE. The
   builder takes a cloud-init enabled virtual machine template name, runs any
   provisioning necessary on the image after launching it, then creates a virtual
   machine template.
 
-- [proxmox-iso](/docs/builders/proxmox/iso) - The proxmox Packer
+- [proxmox-iso](/packer/plugins/builders/proxmox/iso) - The proxmox Packer
   builder is able to create new images for use with Proxmox VE. The builder
   takes an ISO source, runs any provisioning necessary on the image after
   launching it, then creates a virtual machine template.


### PR DESCRIPTION
Correct base path for hyperlink.

During the move to `developer.hashicorp`, the path structure for docs is no longer `/docs`.  I'm putting in this PR for a plugin I use. This change likely needs to be made across all plugin pages. 