### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -30,7 +30,7 @@ segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 If no communicator is defined, an SSH key is generated for use, and is used

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -14,13 +14,13 @@ as new Proxmox Virtual Machine images.
 
 Packer is able to target both ISO and existing Cloud-Init images:
 
-- [proxmox-clone](/docs/builders/proxmox/clone) - The proxmox image
+- [proxmox-clone](/packer/plugins/builders/proxmox/clone) - The proxmox image
   Packer builder is able to create new images for use with Proxmox VE. The
   builder takes a cloud-init enabled virtual machine template name, runs any
   provisioning necessary on the image after launching it, then creates a virtual
   machine template.
 
-- [proxmox-iso](/docs/builders/proxmox/iso) - The proxmox Packer
+- [proxmox-iso](/packer/plugins/builders/proxmox/iso) - The proxmox Packer
   builder is able to create new images for use with Proxmox VE. The builder
   takes an ISO source, runs any provisioning necessary on the image after
   launching it, then creates a virtual machine template.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -30,7 +30,7 @@ segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 If no communicator is defined, an SSH key is generated for use, and is used


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them