### PR TITLE
Fix names of registered builders

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,9 +13,8 @@ import (
 
 func main() {
 	pps := plugin.NewSet()
-	pps.RegisterBuilder(plugin.DEFAULT_NAME, new(proxmoxiso.Builder))
-	pps.RegisterBuilder("proxmox-iso", new(proxmoxiso.Builder))
-	pps.RegisterBuilder("proxmox-clone", new(proxmoxclone.Builder))
+	pps.RegisterBuilder("iso", new(proxmoxiso.Builder))
+	pps.RegisterBuilder("clone", new(proxmoxclone.Builder))
 	pps.SetVersion(version.PluginVersion)
 	err := pps.Run()
 	if err != nil {


### PR DESCRIPTION
Fixes duplicate "proxmox-" prefixes in builder names when running the plugin as an external process.

Doesn't affect bundling by Packer since builder names are defined in [vendored_plugins.go](https://github.com/hashicorp/packer/blob/11e71729f187bad76d28f1701cf2c56e7b912c0f/command/vendored_plugins.go#L117
)

Closes #119
