### PR TITLE
[feature] adds serial ports for iso and clone builder

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -101,6 +101,7 @@ type FlatConfig struct {
 	VGA                       *proxmox.FlatvgaConfig             `mapstructure:"vga" cty:"vga" hcl:"vga"`
 	NICs                      []proxmox.FlatnicConfig            `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
 	Disks                     []proxmox.FlatdiskConfig           `mapstructure:"disks" cty:"disks" hcl:"disks"`
+	Serials                   []string                           `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                              `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController            *string                            `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                    *bool                              `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
@@ -217,6 +218,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vga":                          &hcldec.BlockSpec{TypeName: "vga", Nested: hcldec.ObjectSpec((*proxmox.FlatvgaConfig)(nil).HCL2Spec())},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*proxmox.FlatnicConfig)(nil).HCL2Spec())},
 		"disks":                        &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*proxmox.FlatdiskConfig)(nil).HCL2Spec())},
+		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                       &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -233,6 +233,12 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	if len(c.Serials) > 4 {
 	    errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("serials admit up to 4 elements"))
 	}
+	res := regexp.MustCompile(`^(/dev/.+|socket)$`)
+	for idx := range c.Serials {
+		if !res.MatchString(c.Serials[idx]) {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("serials must respond to pattern \"/dev/.+\" or be \"socket\". It was \"%s\"", c.Serials[idx]))
+		}
+	}
 	if c.SCSIController == "" {
 		log.Printf("SCSI controller not set, using default 'lsi'")
 		c.SCSIController = "lsi"

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -230,6 +230,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disk format must be specified for pool type %q", c.Disks[idx].StoragePoolType))
 		}
 	}
+	if len(c.Serials) > 4 {
+	    errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("serials admit up to 4 elements"))
+	}
 	if c.SCSIController == "" {
 		log.Printf("SCSI controller not set, using default 'lsi'")
 		c.SCSIController = "lsi"

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	VGA            vgaConfig      `mapstructure:"vga"`
 	NICs           []nicConfig    `mapstructure:"network_adapters"`
 	Disks          []diskConfig   `mapstructure:"disks"`
+	Serials        []string       `mapstructure:"serials"`
 	Agent          config.Trilean `mapstructure:"qemu_agent"`
 	SCSIController string         `mapstructure:"scsi_controller"`
 	Onboot         bool           `mapstructure:"onboot"`

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -231,12 +231,12 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		}
 	}
 	if len(c.Serials) > 4 {
-	    errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("serials admit up to 4 elements"))
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("too many serials: %d serials defined, but proxmox accepts 4 elements maximum", len(c.Serials)))
 	}
 	res := regexp.MustCompile(`^(/dev/.+|socket)$`)
-	for idx := range c.Serials {
-		if !res.MatchString(c.Serials[idx]) {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("serials must respond to pattern \"/dev/.+\" or be \"socket\". It was \"%s\"", c.Serials[idx]))
+	for _, serial := range c.Serials {
+		if !res.MatchString(serial) {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("serials must respond to pattern \"/dev/.+\" or be \"socket\". It was \"%s\"", serial))
 		}
 	}
 	if c.SCSIController == "" {

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -100,6 +100,7 @@ type FlatConfig struct {
 	VGA                       *FlatvgaConfig             `mapstructure:"vga" cty:"vga" hcl:"vga"`
 	NICs                      []FlatnicConfig            `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
 	Disks                     []FlatdiskConfig           `mapstructure:"disks" cty:"disks" hcl:"disks"`
+	Serials                   []string                   `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                      `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController            *string                    `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                    *bool                      `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
@@ -214,6 +215,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vga":                          &hcldec.BlockSpec{TypeName: "vga", Nested: hcldec.ObjectSpec((*FlatvgaConfig)(nil).HCL2Spec())},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatnicConfig)(nil).HCL2Spec())},
 		"disks":                        &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*FlatdiskConfig)(nil).HCL2Spec())},
+		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                       &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -242,3 +242,47 @@ func TestAdditionalISOs(t *testing.T) {
 	}
 
 }
+
+func TestSerials(t *testing.T) {
+	serialsTest := []struct {
+		name          string
+		serials       []string
+		expectFailure bool
+	}{
+		{
+			name:          "empty serials, no error",
+			expectFailure: false,
+			serials:       []string{},
+		},
+		{
+			name:          "too many serials, fail",
+			expectFailure: true,
+			serials:       []string{"socket", "socket", "socket", "socket", "socket"},
+		},
+		{
+			name:          "malformed serial, fail",
+			expectFailure: true,
+			serials:       []string{"socket", "/dev/abcde", "/mnt/device"},
+		},
+	}
+
+	for _, tt := range serialsTest {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := mandatoryConfig(t)
+			cfg["serials"] = tt.serials
+
+			var c Config
+			_, _, err := c.Prepare(&c, cfg)
+			if err != nil {
+				if !tt.expectFailure {
+					t.Fatalf("unexpected failure to prepare config: %s", err)
+				}
+				t.Logf("got expected failure: %s", err)
+			}
+
+			if err == nil && tt.expectFailure {
+				t.Errorf("expected failure, but prepare succeeded")
+			}
+		})
+	}
+}

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -65,6 +65,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		QemuVga:      generateProxmoxVga(c.VGA),
 		QemuNetworks: generateProxmoxNetworkAdapters(c.NICs),
 		QemuDisks:    generateProxmoxDisks(c.Disks),
+		QemuSerials:  generateProxmoxSerials(c.Serials),
 		Scsihw:       c.SCSIController,
 		Onboot:       &c.Onboot,
 	}
@@ -193,6 +194,15 @@ func generateProxmoxDisks(disks []diskConfig) proxmox.QemuDevices {
 		if devs[idx]["type"] == "scsi" || devs[idx]["type"] == "virtio" {
 			setDeviceParamIfDefined(devs[idx], "iothread", strconv.FormatBool(disks[idx].IOThread))
 		}
+	}
+	return devs
+}
+
+func generateProxmoxSerials(serials []string) proxmox.QemuDevices {
+	devs := make(proxmox.QemuDevices)
+	for idx := range serials {
+		devs[idx] = make(proxmox.QemuDevice)
+		setDeviceParamIfDefined(devs[idx], "type", serials[idx])
 	}
 	return devs
 }

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -101,6 +101,7 @@ type FlatConfig struct {
 	VGA                       *proxmox.FlatvgaConfig             `mapstructure:"vga" cty:"vga" hcl:"vga"`
 	NICs                      []proxmox.FlatnicConfig            `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
 	Disks                     []proxmox.FlatdiskConfig           `mapstructure:"disks" cty:"disks" hcl:"disks"`
+	Serials                   []string                           `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                              `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController            *string                            `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                    *bool                              `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
@@ -223,6 +224,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vga":                          &hcldec.BlockSpec{TypeName: "vga", Nested: hcldec.ObjectSpec((*proxmox.FlatvgaConfig)(nil).HCL2Spec())},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*proxmox.FlatnicConfig)(nil).HCL2Spec())},
 		"disks":                        &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*proxmox.FlatdiskConfig)(nil).HCL2Spec())},
+		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                       &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -48,6 +48,8 @@
 
 - `disks` ([]diskConfig) - Disks
 
+- `serials` ([]string) - Serials
+
 - `qemu_agent` (boolean) - Agent
 
 - `scsi_controller` (string) - SCSI Controller

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -154,6 +154,18 @@ in the image's Cloud-Init settings for provisioning.
     operating as a router, reverse proxy or a busy HTTP server. Requires
     `virtio` network adapter. Defaults to `0`.
 
+- `serials` ([]string) - A list (max 4 elements) of serial ports attached to
+the virtual machine. It may pass through a host serial device `/dev/ttyS0`
+or create unix socket on the host `socket`. Each element can be `socket`
+or responding to pattern `/dev/.+`. Example:
+
+  ```json
+  [
+    "socket",
+    "/dev/ttyS1"
+  ]
+  ```
+
 - `disks` (array of objects) - Disks attached to the virtual machine.
   Example:
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -169,6 +169,18 @@ in the image's Cloud-Init settings for provisioning.
     operating as a router, reverse proxy or a busy HTTP server. Requires
     `virtio` network adapter. Defaults to `0`.
 
+- `serials` ([]string) - A list (max 4 elements) of serial ports attached to
+the virtual machine. It may pass through a host serial device `/dev/ttyS0`
+or create unix socket on the host `socket`. Each element can be `socket`
+or responding to pattern `/dev/.+`. Example:
+
+  ```json
+  [
+    "socket",
+    "/dev/ttyS1"
+  ]
+  ```
+
 - `disks` (array of objects) - Disks attached to the virtual machine.
   Example:
 


### PR DESCRIPTION
Adds `serials` option which allows user adding from 1 up to 4 serials ports to the packer VM.


Closes #41 

