### PR TITLE
Remove existing Cloud-Init drive before creation

### DIFF
--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -66,6 +66,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook,
 		&commonsteps.StepCleanupTempKeys{
 			Comm: &b.config.Comm,
 		},
+		&stepRemoveCloudInitDrive{},
 		&stepConvertToTemplate{},
 		&stepFinalizeTemplateConfig{},
 		&stepSuccess{},

--- a/builder/proxmox/common/step_remove_cloud_init_drive.go
+++ b/builder/proxmox/common/step_remove_cloud_init_drive.go
@@ -1,0 +1,91 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// stepRemoveCloudInitDrive removes the cloud-init cdrom and deletes
+// VM config parameters related to cloud-init.
+type stepRemoveCloudInitDrive struct{}
+
+type CloudInitDriveRemover interface {
+	GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error)
+	SetVmConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error)
+}
+
+var _ CloudInitDriveRemover = &proxmox.Client{}
+
+func (s *stepRemoveCloudInitDrive) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packersdk.Ui)
+	client := state.Get("proxmoxClient").(CloudInitDriveRemover)
+	vmRef := state.Get("vmRef").(*proxmox.VmRef)
+
+	changes := make(map[string]interface{})
+	delete := []string{}
+
+	vmParams, err := client.GetVmConfig(vmRef)
+	if err != nil {
+		err := fmt.Errorf("error fetching template config: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+	// The cloud-init drive is usually attached to ide0, but check the other controllers as well
+	diskControllers := []string{"ide0", "ide1", "ide2", "ide3"}
+	// Proxmox supports up to 6 SATA controllers (0 - 5)
+	for i := 0; i < 6; i++ {
+		sataController := fmt.Sprintf("sata%d", i)
+		diskControllers = append(diskControllers, sataController)
+	}
+	// and up to 31 SCSI controllers (0 - 30)
+	for i := 0; i < 31; i++ {
+		scsiController := fmt.Sprintf("scsi%d", i)
+		diskControllers = append(diskControllers, scsiController)
+	}
+
+	for _, controller := range diskControllers {
+		if vmParams[controller] != nil && strings.Contains(vmParams[controller].(string), "-cloudinit,media=cdrom") {
+			delete = append(delete, controller)
+		}
+	}
+
+	CloudInitParameters := []string{
+		"cipassword",
+		"ciuser",
+		"nameserver",
+		"searchdomain",
+		"sshkeys",
+	}
+	for i := 0; i < 16; i++ {
+		ipconfig := fmt.Sprintf("ipconfig%d", i)
+		CloudInitParameters = append(CloudInitParameters, ipconfig)
+	}
+	for _, parameter := range CloudInitParameters {
+		if vmParams[parameter] != nil {
+			delete = append(delete, parameter)
+		}
+	}
+
+	if len(delete) > 0 {
+		changes["delete"] = strings.Join(delete, ",")
+
+		_, err := client.SetVmConfig(vmRef, changes)
+		if err != nil {
+			err := fmt.Errorf("error updating template: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepRemoveCloudInitDrive) Cleanup(state multistep.StateBag) {
+}

--- a/builder/proxmox/common/step_remove_cloud_init_drive_test.go
+++ b/builder/proxmox/common/step_remove_cloud_init_drive_test.go
@@ -1,0 +1,118 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type CloudInitDriveRemoverMock struct {
+	getConfig func() (map[string]interface{}, error)
+	setConfig func(map[string]interface{}) (string, error)
+}
+
+func (m CloudInitDriveRemoverMock) GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error) {
+	return m.getConfig()
+}
+func (m CloudInitDriveRemoverMock) SetVmConfig(vmref *proxmox.VmRef, c map[string]interface{}) (interface{}, error) {
+	return m.setConfig(c)
+}
+
+var _ CloudInitDriveRemover = CloudInitDriveRemoverMock{}
+
+func TestRemoveCloudInitDrive(t *testing.T) {
+	cs := []struct {
+		name                string
+		builderConfig       *Config
+		initialVMConfig     map[string]interface{}
+		getConfigErr        error
+		expectCallSetConfig bool
+		expectedDelete      string
+		setConfigErr        error
+		expectedAction      multistep.StepAction
+	}{
+		{
+			name:          "remove Cloud-Init drive",
+			builderConfig: &Config{},
+			initialVMConfig: map[string]interface{}{
+				"ide3": "local-zfs:vm-500-cloudinit,media=cdrom",
+			},
+			expectCallSetConfig: true,
+			expectedDelete:      "ide3",
+			expectedAction:      multistep.ActionContinue,
+		},
+		{
+			name:          "leave other drives alone",
+			builderConfig: &Config{},
+			initialVMConfig: map[string]interface{}{
+				"ide2":  "local:iso/debian-11.6.0-amd64-netinst.iso,media=cdrom,size=388M",
+				"scsi0": "local-zfs:vm-108-disk-0,iothread=1,size=10G",
+			},
+			expectCallSetConfig: false,
+			expectedDelete:      "",
+			expectedAction:      multistep.ActionContinue,
+		},
+		{
+			name:          "find Cloud-Init drive on all controllers",
+			builderConfig: &Config{},
+			initialVMConfig: map[string]interface{}{
+				"ide3":   "local-zfs:vm-104-cloudinit,media=cdrom,size=4M",
+				"sata5":  "local-zfs:vm-104-cloudinit,media=cdrom,size=4M",
+				"scsi30": "local-zfs:vm-104-cloudinit,media=cdrom,size=4M",
+			},
+			expectCallSetConfig: true,
+			expectedDelete:      "ide3,sata5,scsi30",
+			expectedAction:      multistep.ActionContinue,
+		},
+		{
+			name:          "remove cloud-init config options",
+			builderConfig: &Config{},
+			initialVMConfig: map[string]interface{}{
+				"ciuser":       "root",
+				"cipassword":   "$5$FUaXk2yX$2/E0AXhEfGJqxNA6H9ORURyS8WSnsm8uT9S4vvDqwd7",
+				"sshkeys":      "ssh-ed25519%20AAAAC3NzaC1lZDI1NTE5AAAAIEGL6AvL7oe7nQThd8hr6%2FqKeYtQv3oG%2Fur1x2U3AovJ%20packer",
+				"searchdomain": "example.com",
+				"nameserver":   "9.9.9.9 149.112.112.112",
+				"ipconfig0":    "ip=10.0.10.123/24,gw=10.0.10.1",
+			},
+			expectCallSetConfig: true,
+			expectedDelete:      "cipassword,ciuser,nameserver,searchdomain,sshkeys,ipconfig0",
+			expectedAction:      multistep.ActionContinue,
+		},
+	}
+
+	for _, c := range cs {
+		t.Run(c.name, func(t *testing.T) {
+			remover := CloudInitDriveRemoverMock{
+				getConfig: func() (map[string]interface{}, error) {
+					return c.initialVMConfig, c.getConfigErr
+				},
+				setConfig: func(changes map[string]interface{}) (string, error) {
+					if !c.expectCallSetConfig {
+						t.Error("Did not expect SetVmConfig to be called")
+					}
+					if changes["delete"] != c.expectedDelete {
+						t.Errorf("Expected delete to be %s, got %s", c.expectedDelete, changes["delete"])
+					}
+
+					return "", c.setConfigErr
+				},
+			}
+
+			state := new(multistep.BasicStateBag)
+			state.Put("ui", packersdk.TestUi(t))
+			state.Put("config", c.builderConfig)
+			state.Put("vmRef", proxmox.NewVmRef(1))
+			state.Put("proxmoxClient", remover)
+
+			step := stepRemoveCloudInitDrive{}
+			action := step.Run(context.TODO(), state)
+			if action != c.expectedAction {
+				t.Errorf("Expected action to be %v, got %v", c.expectedAction, action)
+			}
+		})
+	}
+}

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -225,10 +225,10 @@ or responding to pattern `/dev/.+`. Example:
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
   Defaults to `lsi`.
 
-- `cloud_init` (bool) - If true, add a Cloud-Init CDROM drive after the virtual machine has been converted to a template.
-  Defaults to `false`.
+- `cloud_init` (bool) - If true, add an empty Cloud-Init CDROM drive after the virtual
+  machine has been converted to a template. Defaults to `false`.
 
-- `cloud_init_storage_pool` - (string) - Name of the Proxmox storage pool
+- `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
 - `additional_iso_files` (array of objects) - Additional ISO files attached to the virtual machine.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -243,10 +243,10 @@ or responding to pattern `/dev/.+`. Example:
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
   Defaults to `lsi`.
 
-- `cloud_init` (bool) - If true, add a Cloud-Init CDROM drive after the virtual machine has been converted to a template.
-  Defaults to `false`.
+- `cloud_init` (bool) - If true, add an empty Cloud-Init CDROM drive after the virtual
+  machine has been converted to a template. Defaults to `false`.
 
-- `cloud_init_storage_pool` - (string) - Name of the Proxmox storage pool
+- `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
 - `additional_iso_files` (array of objects) - Additional ISO files attached to the virtual machine.


### PR DESCRIPTION
If a template is created from a VM with a Cloud-Init drive, the existing drive is neither deleted nor updated in stepFinalizeTemplateConfig and Proxmox throws `TASK ERROR: zfs error: cannot create 'rpool/data/vm-106-cloudinit': dataset already exists` and the build fails.

This PR adds `stepRemoveCloudInitDrive`, which will remove the Cloud-Init drive before finalizing the template.

To produce a clean template, also remove Cloud-Init configuration parameters set during build.
If `cloud_init` is set to true, the resulting drive will be empty.

Tested on PVE 7.3

Closes #112
