### PR TITLE
Draft-PR to show different implementation for clone: Add Cloud-Init networking options

### DIFF
--- a/builder/proxmox/clone/builder.go
+++ b/builder/proxmox/clone/builder.go
@@ -54,10 +54,21 @@ func (*cloneVMCreator) Create(vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQ
 	if c.FullClone.False() {
 		fullClone = 0
 	}
-
 	config.FullClone = &fullClone
+
+	// cloud-init options
 	config.CIuser = comm.SSHUsername
 	config.Sshkeys = string(comm.SSHPublicKey)
+	config.Nameserver = c.Nameserver
+	config.Searchdomain = c.Searchdomain
+	IpconfigMap := make(map[int]interface{})
+	for idx := range c.NICs {
+		if c.NICs[idx].Ipconfig != (proxmox.CloudInitIpconfig{}) {
+			IpconfigMap[idx] = c.NICs[idx].Ipconfig.ToString()
+		}
+	}
+	config.Ipconfig = IpconfigMap
+
 	sourceVmrs, err := client.GetVmRefsByName(c.CloneVM)
 	if err != nil {
 		return err

--- a/builder/proxmox/clone/config.go
+++ b/builder/proxmox/clone/config.go
@@ -13,6 +13,9 @@ type Config struct {
 
 	CloneVM   string         `mapstructure:"clone_vm"`
 	FullClone config.Trilean `mapstructure:"full_clone" required:"false"`
+
+	Nameserver   string `mapstructure:"nameserver"`
+	Searchdomain string `mapstructure:"searchdomain"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, []string, error) {

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -114,6 +114,8 @@ type FlatConfig struct {
 	VMInterface               *string                            `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
 	CloneVM                   *string                            `mapstructure:"clone_vm" cty:"clone_vm" hcl:"clone_vm"`
 	FullClone                 *bool                              `mapstructure:"full_clone" required:"false" cty:"full_clone" hcl:"full_clone"`
+	Nameserver                *string                            `mapstructure:"nameserver" cty:"nameserver" hcl:"nameserver"`
+	Searchdomain              *string                            `mapstructure:"searchdomain" cty:"searchdomain" hcl:"searchdomain"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -231,6 +233,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
 		"clone_vm":                     &hcldec.AttrSpec{Name: "clone_vm", Type: cty.String, Required: false},
 		"full_clone":                   &hcldec.AttrSpec{Name: "full_clone", Type: cty.Bool, Required: false},
+		"nameserver":                   &hcldec.AttrSpec{Name: "nameserver", Type: cty.String, Required: false},
+		"searchdomain":                 &hcldec.AttrSpec{Name: "searchdomain", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -7,6 +7,35 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// FlatCloudInitIpconfig is an auto-generated flat version of CloudInitIpconfig.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatCloudInitIpconfig struct {
+	Ip       *string `mapstructure:"ip" cty:"ip" hcl:"ip"`
+	Gateway  *string `mapstructure:"gateway" cty:"gateway" hcl:"gateway"`
+	Ip6      *string `mapstructure:"ip6" cty:"ip6" hcl:"ip6"`
+	Gateway6 *string `mapstructure:"gateway6" cty:"gateway6" hcl:"gateway6"`
+}
+
+// FlatMapstructure returns a new FlatCloudInitIpconfig.
+// FlatCloudInitIpconfig is an auto-generated flat version of CloudInitIpconfig.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*CloudInitIpconfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatCloudInitIpconfig)
+}
+
+// HCL2Spec returns the hcl spec of a CloudInitIpconfig.
+// This spec is used by HCL to read the fields of CloudInitIpconfig.
+// The decoded values from this spec will then be applied to a FlatCloudInitIpconfig.
+func (*FlatCloudInitIpconfig) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"ip":       &hcldec.AttrSpec{Name: "ip", Type: cty.String, Required: false},
+		"gateway":  &hcldec.AttrSpec{Name: "gateway", Type: cty.String, Required: false},
+		"ip6":      &hcldec.AttrSpec{Name: "ip6", Type: cty.String, Required: false},
+		"gateway6": &hcldec.AttrSpec{Name: "gateway6", Type: cty.String, Required: false},
+	}
+	return s
+}
+
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
@@ -340,12 +369,13 @@ func (*FlatefiConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatnicConfig is an auto-generated flat version of nicConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatnicConfig struct {
-	Model        *string `mapstructure:"model" cty:"model" hcl:"model"`
-	PacketQueues *int    `mapstructure:"packet_queues" cty:"packet_queues" hcl:"packet_queues"`
-	MACAddress   *string `mapstructure:"mac_address" cty:"mac_address" hcl:"mac_address"`
-	Bridge       *string `mapstructure:"bridge" cty:"bridge" hcl:"bridge"`
-	VLANTag      *string `mapstructure:"vlan_tag" cty:"vlan_tag" hcl:"vlan_tag"`
-	Firewall     *bool   `mapstructure:"firewall" cty:"firewall" hcl:"firewall"`
+	Model        *string                `mapstructure:"model" cty:"model" hcl:"model"`
+	PacketQueues *int                   `mapstructure:"packet_queues" cty:"packet_queues" hcl:"packet_queues"`
+	MACAddress   *string                `mapstructure:"mac_address" cty:"mac_address" hcl:"mac_address"`
+	Bridge       *string                `mapstructure:"bridge" cty:"bridge" hcl:"bridge"`
+	VLANTag      *string                `mapstructure:"vlan_tag" cty:"vlan_tag" hcl:"vlan_tag"`
+	Firewall     *bool                  `mapstructure:"firewall" cty:"firewall" hcl:"firewall"`
+	Ipconfig     *FlatCloudInitIpconfig `mapstructure:"ipconfig" cty:"ipconfig" hcl:"ipconfig"`
 }
 
 // FlatMapstructure returns a new FlatnicConfig.
@@ -366,6 +396,7 @@ func (*FlatnicConfig) HCL2Spec() map[string]hcldec.Spec {
 		"bridge":        &hcldec.AttrSpec{Name: "bridge", Type: cty.String, Required: false},
 		"vlan_tag":      &hcldec.AttrSpec{Name: "vlan_tag", Type: cty.String, Required: false},
 		"firewall":      &hcldec.AttrSpec{Name: "firewall", Type: cty.Bool, Required: false},
+		"ipconfig":      &hcldec.BlockSpec{TypeName: "ipconfig", Nested: hcldec.ObjectSpec((*FlatCloudInitIpconfig)(nil).HCL2Spec())},
 	}
 	return s
 }

--- a/builder/proxmox/iso/config.go
+++ b/builder/proxmox/iso/config.go
@@ -46,6 +46,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, []string, error) {
 	if len(c.ISOConfig.ISOUrls) != 0 && c.ISOStoragePool == "" {
 		errs = packersdk.MultiErrorAppend(errs, errors.New("when specifying iso_url, iso_storage_pool must also be specified"))
 	}
+	for idx := range c.NICs {
+		if c.NICs[idx].Ipconfig != (proxmox.CloudInitIpconfig{}) {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("Cloud-Init options are only available when using the proxmox-clone builder"))
+		}
+	}
 
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warnings, errs

--- a/docs-partials/builder/proxmox/common/CloudInitIpconfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/CloudInitIpconfig-not-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the CloudInitIpconfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `ip` (string) - Ip
+
+- `gateway` (string) - Gateway
+
+- `ip6` (string) - Ip 6
+
+- `gateway6` (string) - Gateway 6
+
+<!-- End of code generated from the comments of the CloudInitIpconfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/nicConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/nicConfig-not-required.mdx
@@ -12,4 +12,6 @@
 
 - `firewall` (bool) - Firewall
 
+- `ipconfig` (CloudInitIpconfig) - Ipconfig
+
 <!-- End of code generated from the comments of the nicConfig struct in builder/proxmox/common/config.go; -->

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -122,7 +122,12 @@ in the image's Cloud-Init settings for provisioning.
       "model": "virtio",
       "bridge": "vmbr0",
       "vlan_tag": "10",
-      "firewall": true
+      "firewall": true,
+      "ipconfig": 
+        {
+          "ip": "10.0.10.123/24",
+          "gateway": "10.0.10.1"
+        }
     }
   ]
   ```
@@ -153,6 +158,17 @@ in the image's Cloud-Init settings for provisioning.
     handle a great number of incoming connections, such as when the VM is
     operating as a router, reverse proxy or a busy HTTP server. Requires
     `virtio` network adapter. Defaults to `0`.
+  
+  - `ipconfig` (array of objects) - Set IP address and gateway via Cloud-Init.
+    If no options are given, DHCP will be used.
+
+    - `ip` (string) IPv4 address (CIDR notation).
+
+    - `gateway` (string) IPv4 gateway.
+
+    - `ip6` (string) IPv6 address (CIDR notation).
+
+    - `gateway6` (string) IPv6 gateway.
 
 - `serials` ([]string) - A list (max 4 elements) of serial ports attached to
 the virtual machine. It may pass through a host serial device `/dev/ttyS0`
@@ -230,6 +246,12 @@ or responding to pattern `/dev/.+`. Example:
 
 - `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
+
+- `nameserver` (string) - Set nameserver IP address(es) via Cloud-Init.
+  If not given, the host setting will be used.
+
+- `searchdomain` (string) - Set the DNS searchdomain via Cloud-Init.
+  If not given, the host setting will be used.
 
 - `additional_iso_files` (array of objects) - Additional ISO files attached to the virtual machine.
   Example:


### PR DESCRIPTION
Allows to write the configuration like this:
```json
[
  {
    "model": "virtio",
    "bridge": "vmbr0",
    "vlan_tag": "10",
    "firewall": true,
    "ipconfig": 
      {
        "ip": "10.0.10.123/24",
        "gateway": "10.0.10.1"
      }
  }
]
```