### PR TITLE
Address differences between `iso` and `clone` regarding disk creation.

### DIFF
--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -125,9 +125,9 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		}
 	}
 
-	// The EFI disk doesn't get created reliably during initial VM creation,
+	// The EFI disk doesn't get created reliably when using the clone builder,
 	// so let's make sure it's there.
-	if c.EFIConfig != (efiConfig{}) {
+	if c.EFIConfig != (efiConfig{}) && c.Ctx.BuildType == "proxmox-clone" {
 		addEFIConfig := make(map[string]interface{})
 		err := config.CreateQemuEfiParams(addEFIConfig)
 		if err != nil {

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -20,6 +20,10 @@ machine template, runs any provisioning necessary on the image after launching i
 then creates a virtual machine template. This template can then be used as to
 create new virtual machines within Proxmox.
 
+Disks specified in a `proxmox-clone` builder configuration will replace disks
+that are already present on the cloned VM template. If you want to reuse the disks
+of the cloned VM, don't specify disks in your configuration.
+
 The builder does _not_ manage templates. Once it creates a template, it is up
 to you to use it or delete it.
 


### PR DESCRIPTION
The new `efi_config` brought differences between `iso` and `clone` to light.
The first difference is that `iso` will create the EFI disk in the first run and the additional call of `SetVmConfig` is not needed.
The second one is that `clone` will replace disks that are already present on the cloned VM with the ones specified in the builder configuration.

I addressed both differences in separate commits.

Closes #145 

