### PR TITLE
docs: fix machine attribute docs

### DIFF
--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -338,7 +338,7 @@ or responding to pattern `/dev/.+`. Example:
 
 - `efidisk` - (string) - This option is deprecated, please use `efi_config` instead.
 
-- `machine` - (string) - Set themachine type. i440fx or q35.
+- `machine` - (string) - Set the machine type. Supported values are 'pc', 'pc-i440fx' or 'q35'.
 
 ## Example: Cloud-Init enabled Debian
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -382,7 +382,7 @@ or responding to pattern `/dev/.+`. Example:
 
 - `efidisk` - (string) - This option is deprecated, please use `efi_config` instead.
 
-- `machine` - (string) - Set themachine type. i440fx or q35.
+- `machine` - (string) - Set the machine type. Supported values are 'pc', 'pc-i440fx' or 'q35'.
 
 ## Boot Command
 


### PR DESCRIPTION
The machine attribute docs mistakenly documented the possible values as either i440fx or q35, while the code checked for pc, pc-i440fx or q35.

To make the documentation closer to what the code actually does, we update this section.

Reported by #154 