### PR TITLE
clone: Add support to clone VM by ID, check if VM IDs are in valid range.

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -113,6 +113,7 @@ type FlatConfig struct {
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
 	VMInterface               *string                            `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
 	CloneVM                   *string                            `mapstructure:"clone_vm" required:"true" cty:"clone_vm" hcl:"clone_vm"`
+	CloneVMID                 *int                               `mapstructure:"clone_vm_id" required:"true" cty:"clone_vm_id" hcl:"clone_vm_id"`
 	FullClone                 *bool                              `mapstructure:"full_clone" required:"false" cty:"full_clone" hcl:"full_clone"`
 	Nameserver                *string                            `mapstructure:"nameserver" required:"false" cty:"nameserver" hcl:"nameserver"`
 	Searchdomain              *string                            `mapstructure:"searchdomain" required:"false" cty:"searchdomain" hcl:"searchdomain"`
@@ -233,6 +234,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
 		"clone_vm":                     &hcldec.AttrSpec{Name: "clone_vm", Type: cty.String, Required: false},
+		"clone_vm_id":                  &hcldec.AttrSpec{Name: "clone_vm_id", Type: cty.Number, Required: false},
 		"full_clone":                   &hcldec.AttrSpec{Name: "full_clone", Type: cty.Bool, Required: false},
 		"nameserver":                   &hcldec.AttrSpec{Name: "nameserver", Type: cty.String, Required: false},
 		"searchdomain":                 &hcldec.AttrSpec{Name: "searchdomain", Type: cty.String, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -169,6 +169,12 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		c.BootKeyInterval = 5 * time.Millisecond
 	}
 
+	// Technically Proxmox VMIDs are unsigned 32bit integers, but are limited to
+	// the range 100-999999999. Source:
+	// https://pve-devel.pve.proxmox.narkive.com/Pa6mH1OP/avoiding-vmid-reuse#post8
+	if c.VMID != 0 && (c.VMID < 100 || c.VMID > 999999999) {
+		errs = packersdk.MultiErrorAppend(errs, errors.New("vm_id must be in range 100-999999999"))
+	}
 	if c.VMName == "" {
 		// Default to packer-[time-ordered-uuid]
 		c.VMName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -286,3 +286,52 @@ func TestSerials(t *testing.T) {
 		})
 	}
 }
+
+func TestVMID(t *testing.T) {
+	serialsTest := []struct {
+		name          string
+		VMID          int
+		expectFailure bool
+	}{
+		{
+			name:          "VMID zero, no error",
+			expectFailure: false,
+			VMID:          0,
+		},
+		{
+			name:          "VMID in range, no error",
+			expectFailure: false,
+			VMID:          1000,
+		},
+		{
+			name:          "VMID above range, fail",
+			expectFailure: true,
+			VMID:          1000000000,
+		},
+		{
+			name:          "VMID below range, fail",
+			expectFailure: true,
+			VMID:          50,
+		},
+	}
+
+	for _, tt := range serialsTest {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := mandatoryConfig(t)
+			cfg["vm_id"] = tt.VMID
+
+			var c Config
+			_, _, err := c.Prepare(&c, cfg)
+			if err != nil {
+				if !tt.expectFailure {
+					t.Fatalf("unexpected failure to prepare config: %s", err)
+				}
+				t.Logf("got expected failure: %s", err)
+			}
+
+			if err == nil && tt.expectFailure {
+				t.Errorf("expected failure, but prepare succeeded")
+			}
+		})
+	}
+}

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -68,6 +68,11 @@ in the image's Cloud-Init settings for provisioning.
   machine on during creation.
 
 - `clone_vm` (string) - The name of the VM Packer should clone and build from.
+  Either `clone_vm` or `clone_vm_id` must be specifed.
+
+- `clone_vm_id` (int) - The ID of the VM Packer should clone and build from.
+  Proxmox VMIDs are limited to the range 100-999999999.
+  Either `clone_vm` or `clone_vm_id` must be specifed.
 
 ### Optional:
 

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -87,8 +87,9 @@ in the image's Cloud-Init settings for provisioning.
   given, a random uuid will be used.
 
 - `vm_id` (int) - The ID used to reference the virtual machine. This will
-  also be the ID of the final template. If not given, the next free ID on
-  the node will be used.
+  also be the ID of the final template. Proxmox VMIDs are unique cluster-wide
+  and are limited to the range 100-999999999.
+  If not given, the next free ID on the cluster will be used.
 
 - `memory` (int) - How much memory, in megabytes, to give the virtual
   machine. Defaults to `512`.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -98,8 +98,9 @@ in the image's Cloud-Init settings for provisioning.
   given, a random uuid will be used.
 
 - `vm_id` (int) - The ID used to reference the virtual machine. This will
-  also be the ID of the final template. If not given, the next free ID on
-  the node will be used.
+  also be the ID of the final template. Proxmox VMIDs are unique cluster-wide
+  and are limited to the range 100-999999999.
+  If not given, the next free ID on the cluster will be used.
 
 - `memory` (int) - How much memory, in megabytes, to give the virtual
   machine. Defaults to `512`.


### PR DESCRIPTION
The clone builder currently supports cloning VMs by name only. Add a new attribute `clone_vm_id` to be able to clone VMs by ID, too.

The valid VMID ranges for Proxmox are hard to find, the only reference I found was this: https://pve-devel.pve.proxmox.narkive.com/Pa6mH1OP/avoiding-vmid-reuse#post8
I confirmed these numbers by testing on a PVE 7.3, so I also added the range-check for `vm_id` in a second commit.