### PR TITLE
docs: update machine docs without i440fx

### DIFF
--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -338,7 +338,7 @@ or responding to pattern `/dev/.+`. Example:
 
 - `efidisk` - (string) - This option is deprecated, please use `efi_config` instead.
 
-- `machine` - (string) - Set the machine type. Supported values are 'pc', 'pc-i440fx' or 'q35'.
+- `machine` - (string) - Set the machine type. Supported values are 'pc' or 'q35'.
 
 ## Example: Cloud-Init enabled Debian
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -387,7 +387,7 @@ or responding to pattern `/dev/.+`. Example:
 
 - `efidisk` - (string) - This option is deprecated, please use `efi_config` instead.
 
-- `machine` - (string) - Set the machine type. Supported values are 'pc', 'pc-i440fx' or 'q35'.
+- `machine` - (string) - Set the machine type. Supported values are 'pc' or 'q35'.
 
 ## Boot Command
 


### PR DESCRIPTION
The i440fx machine type is advertised as supported by the Proxmox API client incorrectly, as it is then rejected by proxmox since the i440fx machine type is only supported with a version identifier, which will then be rejected by the API client.

To avoid confusion in the docs, we remove the reference to i440fx, and only document the `pc` and `q35` values as they are both accepted by proxmox and the API client.

Related to #154 