### PR TITLE
docs: Update example templates

### DIFF
--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -356,26 +356,67 @@ Here is a basic example creating a Debian 10 server image. This assumes
 that there exists a Cloud-Init enabled image on the Proxmox server named
 `debian-10-4`.
 
+<Tabs>
+<Tab heading="HCL2">
+
+```hcl
+variable "proxmox_password" {
+  type    = string
+  default = "supersecret"
+}
+
+variable "proxmox_username" {
+  type    = string
+  default = "apiuser@pve"
+}
+
+source "proxmox-clone" "debian" {
+  clone_vm                 = "debian-10-4"
+  cores                    = 1
+  insecure_skip_tls_verify = true
+  memory                   = 2048
+  network_adapters {
+    bridge = "vmbr0"
+    model  = "virtio"
+  }
+  node                 = "pve"
+  os                   = "l26"
+  password             = "${var.proxmox_password}"
+  pool                 = "api-users"
+  proxmox_url          = "https://my-proxmox.my-domain:8006/api2/json"
+  sockets              = 1
+  ssh_username         = "root"
+  template_description = "image made from cloud-init image"
+  template_name        = "debian-scaffolding"
+  username             = "${var.proxmox_username}"
+}
+
+build {
+  sources = ["source.proxmox-clone.debian"]
+}
+```
+
+</Tab>
+<Tab heading="JSON">
+
 ```json
 {
   "variables": {
-    "proxmox_url": "{{env `PROXMOX_URL`}}",
-    "proxmox_username": "{{env `PROXMOX_USERNAME`}}",
-    "proxmox_password": "{{env `PROXMOX_PASSWORD`}}"
+    "proxmox_username": "apiuser@pve",
+    "proxmox_password": "supersecret"
   },
-
   "builders": [
     {
       "type": "proxmox-clone",
-      "proxmox_url": "{{user `proxmox_url`}}",
+      "proxmox_url": "https://my-proxmox.my-domain:8006/api2/json",
       "username": "{{user `proxmox_username`}}",
       "password": "{{user `proxmox_password`}}",
+      "ssh_username": "root",
       "node": "pve",
       "insecure_skip_tls_verify": true,
       "clone_vm": "debian-10-4",
       "template_name": "debian-scaffolding",
       "template_description": "image made from cloud-init image",
-
       "pool": "api-users",
       "os": "l26",
       "cores": 1,
@@ -383,11 +424,14 @@ that there exists a Cloud-Init enabled image on the Proxmox server named
       "memory": 2048,
       "network_adapters": [
         {
+          "model": "virtio",
           "bridge": "vmbr0"
         }
       ]
     }
-  ],
-  "description": "A template for building a base"
+  ]
 }
 ```
+
+</Tab>
+</Tabs>

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -415,6 +415,61 @@ Here is a basic example creating a Fedora 29 server image with a Kickstart
 file served with Packer's HTTP server. Note that the iso file needs to be
 manually downloaded.
 
+<Tabs>
+<Tab heading="HCL2">
+
+```hcl
+variable "password" {
+  type    = string
+  default = "supersecret"
+}
+
+variable "username" {
+  type    = string
+  default = "apiuser@pve"
+}
+
+source "proxmox-iso" "fedora-kickstart" {
+  boot_command = ["<up><tab> ip=dhcp inst.cmdline inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter>"]
+  boot_wait    = "10s"
+  disks {
+    disk_size         = "5G"
+    storage_pool      = "local-lvm"
+    storage_pool_type = "lvm"
+    type              = "scsi"
+  }
+  efi_config {
+    efi_storage_pool  = "local-lvm"
+    efi_type          = "4m"
+    pre_enrolled_keys = true
+  }
+  http_directory           = "config"
+  insecure_skip_tls_verify = true
+  iso_file                 = "local:iso/Fedora-Server-dvd-x86_64-29-1.2.iso"
+  network_adapters {
+    bridge = "vmbr0"
+    model  = "virtio"
+  }
+  node                 = "my-proxmox"
+  password             = "${var.password}"
+  proxmox_url          = "https://my-proxmox.my-domain:8006/api2/json"
+  ssh_password         = "packer"
+  ssh_timeout          = "15m"
+  ssh_username         = "root"
+  template_description = "Fedora 29-1.2, generated on ${timestamp()}"
+  template_name        = "fedora-29"
+  unmount_iso          = true
+  username             = "${var.username}"
+}
+
+build {
+  sources = ["source.proxmox-iso.fedora-kickstart"]
+}
+```
+
+</Tab>
+<Tab heading="JSON">
+
 ```json
 {
   "variables": {
@@ -423,15 +478,15 @@ manually downloaded.
   },
   "builders": [
     {
-      "type": "proxmox",
+      "type": "proxmox-iso",
       "proxmox_url": "https://my-proxmox.my-domain:8006/api2/json",
       "insecure_skip_tls_verify": true,
       "username": "{{user `username`}}",
       "password": "{{user `password`}}",
-
       "node": "my-proxmox",
       "network_adapters": [
         {
+          "model": "virtio",
           "bridge": "vmbr0"
         }
       ],
@@ -443,18 +498,20 @@ manually downloaded.
           "storage_pool_type": "lvm"
         }
       ],
-
+      "efi_config": {
+          "efi_storage_pool": "local-lvm",
+          "pre_enrolled_keys": true,
+          "efi_type": "4m"
+      },
       "iso_file": "local:iso/Fedora-Server-dvd-x86_64-29-1.2.iso",
       "http_directory": "config",
       "boot_wait": "10s",
       "boot_command": [
         "<up><tab> ip=dhcp inst.cmdline inst.ks=http://{{.HTTPIP}}:{{.HTTPPort}}/ks.cfg<enter>"
       ],
-
       "ssh_username": "root",
       "ssh_timeout": "15m",
       "ssh_password": "packer",
-
       "unmount_iso": true,
       "template_name": "fedora-29",
       "template_description": "Fedora 29-1.2, generated on {{ isotime \"2006-01-02T15:04:05Z\" }}"
@@ -462,3 +519,6 @@ manually downloaded.
   ]
 }
 ```
+
+</Tab>
+</Tabs>


### PR DESCRIPTION
I guess most new users will use the full templates provided in the documentation as a starting point. To have working examples out of the box, I did two corrections:
- use `proxmox-iso` instead of `proxmox` (this was a leftover from the plugin split, I guess)
- add `ssh_username` to `clone`

I used `packer hcl2_upgrade` to add HCL2 examples for both builders as well.

I plan to add HCL2 blocks for the smaller inline examples as well, but I'd like to think about possibilities to restructure the documentation first.
