### PR TITLE
Deprecate `storage_pool_type`, config refactor

### DIFF
--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -200,12 +200,6 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		log.Printf("OS not set, using default 'other'")
 		c.OS = "other"
 	}
-	for idx := range c.NICs {
-		if c.NICs[idx].Model == "" {
-			log.Printf("NIC %d model not set, using default 'e1000'", idx)
-			c.NICs[idx].Model = "e1000"
-		}
-	}
 	for idx := range c.Disks {
 		if c.Disks[idx].Type == "" {
 			log.Printf("Disk %d type not set, using default 'scsi'", idx)
@@ -280,14 +274,18 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	if c.TemplateName != "" && !re.MatchString(c.TemplateName) {
 		errs = packersdk.MultiErrorAppend(errs, errors.New("template_name must be a valid DNS name"))
 	}
-	for idx := range c.NICs {
-		if c.NICs[idx].Bridge == "" {
+	for idx, nic := range c.NICs {
+		if nic.Bridge == "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("network_adapters[%d].bridge must be specified", idx))
 		}
-		if c.NICs[idx].Model != "virtio" && c.NICs[idx].PacketQueues > 0 {
+		if nic.Model == "" {
+			log.Printf("NIC %d model not set, using default 'e1000'", idx)
+			c.NICs[idx].Model = "e1000"
+		}
+		if nic.Model != "virtio" && nic.PacketQueues > 0 {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("network_adapters[%d].packet_queues can only be set for 'virtio' driver", idx))
 		}
-		if (c.NICs[idx].MTU < 0) || (c.NICs[idx].MTU > 65520) {
+		if (nic.MTU < 0) || (nic.MTU > 65520) {
 			errs = packersdk.MultiErrorAppend(errs, errors.New("network_adapters[%d].mtu only positive values up to 65520 are supported"))
 		}
 	}

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -271,7 +271,6 @@ func generateProxmoxDisks(disks []diskConfig) proxmox.QemuDevices {
 		setDeviceParamIfDefined(devs[idx], "type", disks[idx].Type)
 		setDeviceParamIfDefined(devs[idx], "size", disks[idx].Size)
 		setDeviceParamIfDefined(devs[idx], "storage", disks[idx].StoragePool)
-		setDeviceParamIfDefined(devs[idx], "storage_type", disks[idx].StoragePoolType)
 		setDeviceParamIfDefined(devs[idx], "cache", disks[idx].CacheMode)
 		setDeviceParamIfDefined(devs[idx], "format", disks[idx].DiskFormat)
 

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -198,8 +198,7 @@ or responding to pattern `/dev/.+`. Example:
     to store the virtual machine disk on. A `local-lvm` pool is allocated
     by the installer, for example.
 
-  - `storage_pool_type` (string) - Required. The type of the pool, can
-    be `lvm`, `lvm-thin`, `zfspool`, `cephfs`, `rbd` or `directory`.
+  - `storage_pool_type` (string) - This option is deprecated.
 
   - `type` (string) - The type of disk. Can be `scsi`, `sata`, `virtio` or
     `ide`. Defaults to `scsi`.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -209,8 +209,7 @@ or responding to pattern `/dev/.+`. Example:
     to store the virtual machine disk on. A `local-lvm` pool is allocated
     by the installer, for example.
 
-  - `storage_pool_type` (string) - Required. The type of the pool, can
-    be `lvm`, `lvm-thin`, `zfspool`, `cephfs`, `rbd` or `directory`.
+  - `storage_pool_type` (string) - This option is deprecated.
 
   - `type` (string) - The type of disk. Can be `scsi`, `sata`, `virtio` or
     `ide`. Defaults to `scsi`.
@@ -435,7 +434,6 @@ source "proxmox-iso" "fedora-kickstart" {
   disks {
     disk_size         = "5G"
     storage_pool      = "local-lvm"
-    storage_pool_type = "lvm"
     type              = "scsi"
   }
   efi_config {
@@ -494,8 +492,7 @@ build {
         {
           "type": "scsi",
           "disk_size": "5G",
-          "storage_pool": "local-lvm",
-          "storage_pool_type": "lvm"
+          "storage_pool": "local-lvm"
         }
       ],
       "efi_config": {


### PR DESCRIPTION
I refactored the NIC and disk loops as discussed in #165.
While refactoring the disk iteration I remembered #138 and did some research on that. As it turns out we can deprecate `storage_pool_type` without problems, see this comment for details: https://github.com/hashicorp/packer-plugin-proxmox/issues/138#issuecomment-1452280080

I split the two refactorings in two commits to make this easier to review.
Tested on PVE 7.3.

Closes #138
