### PR TITLE
Register "proxmox" builder again

### DIFF
--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -139,6 +139,10 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	var errs *packersdk.MultiError
 	var warnings []string
 
+	if c.Ctx.BuildType == "proxmox" {
+		warnings = append(warnings, "proxmox is deprecated, please use proxmox-iso instead")
+	}
+
 	// Default qemu_agent to true
 	if c.Agent != config.TriFalse {
 		c.Agent = config.TriTrue

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 
 func main() {
 	pps := plugin.NewSet()
+	// When the builder was split, the alias "proxmox" was added to Packer for the iso builder.
+	// Registering 'plugin.DEFAULT_NAME' does the same for the external plugin.
+	pps.RegisterBuilder(plugin.DEFAULT_NAME, new(proxmoxiso.Builder))
 	pps.RegisterBuilder("iso", new(proxmoxiso.Builder))
 	pps.RegisterBuilder("clone", new(proxmoxclone.Builder))
 	pps.SetVersion(version.PluginVersion)


### PR DESCRIPTION
This solves the issue described in https://github.com/hashicorp/packer/issues/12309

While updating the builder names in #120 I wasn't aware that we still need to register a builder with `plugin.DEFAULT_NAME`.

Apparently a lot of users still use the old builder name.

Closes [#12309](https://github.com/hashicorp/packer/issues/12309)

