### PR TITLE
Add support for KVM memory ballooning

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -90,6 +90,7 @@ type FlatConfig struct {
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
+	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
 	Cores                     *int                               `mapstructure:"cores" cty:"cores" hcl:"cores"`
 	CPUType                   *string                            `mapstructure:"cpu_type" cty:"cpu_type" hcl:"cpu_type"`
 	Sockets                   *int                               `mapstructure:"sockets" cty:"sockets" hcl:"sockets"`
@@ -211,6 +212,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
+		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},
 		"cores":                        &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
 		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},
 		"sockets":                      &hcldec.AttrSpec{Name: "sockets", Type: cty.Number, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -50,6 +50,7 @@ type Config struct {
 
 	Boot           string         `mapstructure:"boot"`
 	Memory         int            `mapstructure:"memory"`
+	BalloonMinimum int            `mapstructure:"ballooning_minimum"`
 	Cores          int            `mapstructure:"cores"`
 	CPUType        string         `mapstructure:"cpu_type"`
 	Sockets        int            `mapstructure:"sockets"`
@@ -186,6 +187,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	if c.Memory < 16 {
 		log.Printf("Memory %d is too small, using default: 512", c.Memory)
 		c.Memory = 512
+	}
+	if c.Memory < c.BalloonMinimum {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("ballooning_minimum (%d) must be lower than memory (%d)", c.BalloonMinimum, c.Memory))
 	}
 	if c.Cores < 1 {
 		log.Printf("Number of cores %d is too small, using default: 1", c.Cores)

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -89,6 +89,7 @@ type FlatConfig struct {
 	VMID                      *int                       `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Boot                      *string                    `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                       `mapstructure:"memory" cty:"memory" hcl:"memory"`
+	BalloonMinimum            *int                       `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
 	Cores                     *int                       `mapstructure:"cores" cty:"cores" hcl:"cores"`
 	CPUType                   *string                    `mapstructure:"cpu_type" cty:"cpu_type" hcl:"cpu_type"`
 	Sockets                   *int                       `mapstructure:"sockets" cty:"sockets" hcl:"sockets"`
@@ -204,6 +205,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
+		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},
 		"cores":                        &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
 		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},
 		"sockets":                      &hcldec.AttrSpec{Name: "sockets", Type: cty.Number, Required: false},

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -131,6 +131,13 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Onboot:       &c.Onboot,
 	}
 
+	// 0 disables the ballooning device, which is useful for all VMs
+	// and should be kept enabled by default.
+	// See https://github.com/hashicorp/packer-plugin-proxmox/issues/127#issuecomment-1464030102
+	if c.BalloonMinimum > 0 {
+		config.Balloon = c.BalloonMinimum
+	}
+
 	if c.PackerForce {
 		ui.Say("Force set, checking for existing artifact on PVE cluster")
 		vmRef, err := getExistingTemplate(c, client)

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -90,6 +90,7 @@ type FlatConfig struct {
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
+	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
 	Cores                     *int                               `mapstructure:"cores" cty:"cores" hcl:"cores"`
 	CPUType                   *string                            `mapstructure:"cpu_type" cty:"cpu_type" hcl:"cpu_type"`
 	Sockets                   *int                               `mapstructure:"sockets" cty:"sockets" hcl:"sockets"`
@@ -214,6 +215,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
+		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},
 		"cores":                        &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
 		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},
 		"sockets":                      &hcldec.AttrSpec{Name: "sockets", Type: cty.Number, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -26,6 +26,8 @@
 
 - `memory` (int) - Memory
 
+- `ballooning_minimum` (int) - Balloon Minimum
+
 - `cores` (int) - Cores
 
 - `cpu_type` (string) - CPU Type

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -91,8 +91,14 @@ in the image's Cloud-Init settings for provisioning.
   and are limited to the range 100-999999999.
   If not given, the next free ID on the cluster will be used.
 
-- `memory` (int) - How much memory, in megabytes, to give the virtual
-  machine. Defaults to `512`.
+- `memory` (int) - How much memory (in megabytes) to give the virtual
+  machine. If `ballooning_minimum` is also set, `memory` defines the maximum amount
+  of memory the VM will be able to use.
+  Defaults to `512`.
+
+- `ballooning_minimum` (int) - Setting this option enables KVM memory ballooning and
+  defines the minimum amount of memory (in megabytes) the VM will have.
+  Defaults to `0` (memory ballooning disabled).
 
 - `cores` (int) - How many CPU cores to give the virtual machine. Defaults
   to `1`.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -102,8 +102,14 @@ in the image's Cloud-Init settings for provisioning.
   and are limited to the range 100-999999999.
   If not given, the next free ID on the cluster will be used.
 
-- `memory` (int) - How much memory, in megabytes, to give the virtual
-  machine. Defaults to `512`.
+- `memory` (int) - How much memory (in megabytes) to give the virtual
+  machine. If `ballooning_minimum` is also set, `memory` defines the maximum amount
+  of memory the VM will be able to use.
+  Defaults to `512`.
+
+- `ballooning_minimum` (int) - Setting this option enables KVM memory ballooning and
+  defines the minimum amount of memory (in megabytes) the VM will have.
+  Defaults to `0` (memory ballooning disabled).
 
 - `cores` (int) - How many CPU cores to give the virtual machine. Defaults
   to `1`.


### PR DESCRIPTION
This PR adds the attribute `ballooning_minimum`.
For details, see https://github.com/hashicorp/packer-plugin-proxmox/issues/127#issuecomment-1464030102

Tested on PVE 7.3.

Closes #127
