### PR TITLE
clone: Add dhcp and auto options for ipconfig

### DIFF
--- a/builder/proxmox/clone/config.go
+++ b/builder/proxmox/clone/config.go
@@ -66,7 +66,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, []string, error) {
 		}
 	}
 	for _, i := range c.Ipconfigs {
-		if i.Ip != "" {
+		if i.Ip != "" && i.Ip != "dhcp" {
 			_, _, err := net.ParseCIDR(i.Ip)
 			if err != nil {
 				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("could not parse ipconfig.ip: %s", err))
@@ -78,7 +78,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, []string, error) {
 				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("could not parse ipconfig.gateway: %s", err))
 			}
 		}
-		if i.Ip6 != "" {
+		if i.Ip6 != "" && i.Ip6 != "auto" && i.Ip6 != "dhcp" {
 			_, _, err := net.ParseCIDR(i.Ip6)
 			if err != nil {
 				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("could not parse ipconfig.ip6: %s", err))

--- a/builder/proxmox/clone/config_test.go
+++ b/builder/proxmox/clone/config_test.go
@@ -237,6 +237,22 @@ func TestIpconfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "ipconfig DHCP, no error",
+			expectFailure: false,
+			ipconfigs: []cloudInitIpconfig{
+				{
+					Ip:  "dhcp",
+					Ip6: "dhcp",
+				},
+			},
+			nics: []proxmox.NICConfig{
+				{
+					Model:  "virtio",
+					Bridge: "vmbr0",
+				},
+			},
+		},
 	}
 
 	for _, tt := range ipconfigTest {

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -251,7 +251,6 @@ or responding to pattern `/dev/.+`. Example:
   If not given, the same setting as on the host is used.
 
 - `ipconfig` (array of objects) - Set IP address and gateway via Cloud-Init.
-  If no options are given, DHCP will be used.
   If you have configured more than one network interface, make sure to match the order of
   `network_adapters` and `ipconfig`. 
 
@@ -268,13 +267,13 @@ or responding to pattern `/dev/.+`. Example:
   ]
   ```
 
-  - `ip` (string) IPv4 address (CIDR notation).
+  - `ip` (string) - Either an IPv4 address (CIDR notation) or `dhcp`.
 
-  - `gateway` (string) IPv4 gateway.
+  - `gateway` (string) - IPv4 gateway.
 
-  - `ip6` (string) IPv6 address (CIDR notation).
+  - `ip6` (string) - Can be an IPv6 address (CIDR notation), `auto` (enables SLAAC), or `dhcp`.
 
-  - `gateway6` (string) IPv6 gateway.
+  - `gateway6` (string) - IPv6 gateway.
 
 - `additional_iso_files` (array of objects) - Additional ISO files attached to the virtual machine.
   Example:


### PR DESCRIPTION
Contrary to the initial Cloud-Init networking PR (#142) DHCP has to be enabled explicitly.
Add and document the options to enable DHCP or SLAAC.

Tested on PVE 7.3.
