### PR TITLE
Add iso_download_pve feature to additional_iso_files

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -658,6 +658,8 @@ In HCL2:
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
+- `iso_download_pve` (bool) - ISO Download PVE
+
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -658,7 +658,9 @@ In HCL2:
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
-- `iso_download_pve` (bool) - ISO Download PVE
+- `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
+  
+  Defaults to `false`
 
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -216,10 +216,9 @@ in the image's Cloud-Init settings for provisioning.
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
-- `iso_download_pve` (bool) - Download the specified `iso_url` directly from
-  the PVE node. Defaults to `false`.
-  By default Packer downloads the ISO and uploads it in a second step, this
-  option lets Proxmox handle downloading the ISO directly from the server.
+- `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
+  
+  Defaults to `false`
 
 - `unmount_iso` (bool) - If true, remove the mounted ISO from the template
   after finishing. Defaults to `false`.
@@ -416,7 +415,9 @@ In HCL2:
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
-- `iso_download_pve` (bool) - ISO Download PVE
+- `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
+  
+  Defaults to `false`
 
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -416,6 +416,8 @@ In HCL2:
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
+- `iso_download_pve` (bool) - ISO Download PVE
+
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -76,24 +76,32 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook,
 	}
 	preSteps := b.preSteps
 	for idx := range b.config.AdditionalISOFiles {
-		preSteps = append(preSteps,
-			&commonsteps.StepCreateCD{
-				Files:   b.config.AdditionalISOFiles[idx].CDConfig.CDFiles,
-				Content: b.config.AdditionalISOFiles[idx].CDConfig.CDContent,
-				Label:   b.config.AdditionalISOFiles[idx].CDConfig.CDLabel,
-			},
-			&commonsteps.StepDownload{
-				Checksum:    b.config.AdditionalISOFiles[idx].ISOChecksum,
-				Description: "additional ISO",
-				Extension:   b.config.AdditionalISOFiles[idx].TargetExtension,
-				ResultKey:   b.config.AdditionalISOFiles[idx].DownloadPathKey,
-				TargetPath:  b.config.AdditionalISOFiles[idx].DownloadPathKey,
-				Url:         b.config.AdditionalISOFiles[idx].ISOUrls,
-			},
-			&stepUploadAdditionalISO{
-				ISO: &b.config.AdditionalISOFiles[idx],
-			},
-		)
+		if b.config.AdditionalISOFiles[idx].ISODownloadPVE {
+			preSteps = append(preSteps,
+				&stepDownloadISOOnPVE{
+					ISO: &b.config.AdditionalISOFiles[idx],
+				},
+			)
+		} else {
+			preSteps = append(preSteps,
+				&commonsteps.StepCreateCD{
+					Files:   b.config.AdditionalISOFiles[idx].CDConfig.CDFiles,
+					Content: b.config.AdditionalISOFiles[idx].CDConfig.CDContent,
+					Label:   b.config.AdditionalISOFiles[idx].CDConfig.CDLabel,
+				},
+				&commonsteps.StepDownload{
+					Checksum:    b.config.AdditionalISOFiles[idx].ISOChecksum,
+					Description: "additional ISO",
+					Extension:   b.config.AdditionalISOFiles[idx].TargetExtension,
+					ResultKey:   b.config.AdditionalISOFiles[idx].DownloadPathKey,
+					TargetPath:  b.config.AdditionalISOFiles[idx].DownloadPathKey,
+					Url:         b.config.AdditionalISOFiles[idx].ISOUrls,
+				},
+				&stepUploadAdditionalISO{
+					ISO: &b.config.AdditionalISOFiles[idx],
+				},
+			)
+		}
 	}
 
 	steps := append(preSteps, coreSteps...)

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -759,7 +759,7 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("one of iso_file, iso_url, or a combination of cd_files and cd_content must be specified for AdditionalISO file %s", c.AdditionalISOFiles[idx].Device))
 		}
 		if len(c.AdditionalISOFiles[idx].ISOConfig.ISOUrls) == 0 && c.AdditionalISOFiles[idx].ISOConfig.RawSingleISOUrl == "" && c.AdditionalISOFiles[idx].ISODownloadPVE {
-			err = packersdk.MultiErrorAppend(errs, fmt.Errorf("iso_download_pve can only be used together with iso_url"))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("iso_download_pve can only be used together with iso_url"))
 		}
 	}
 	if c.EFIDisk != "" {

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -226,7 +226,10 @@ type additionalISOsConfig struct {
 	// Proxmox storage pool onto which to upload
 	// the ISO file.
 	ISOStoragePool string `mapstructure:"iso_storage_pool"`
-	ISODownloadPVE bool   `mapstructure:"iso_download_pve"`
+	// Download the ISO directly from the PVE node rather than through Packer.
+	//
+	// Defaults to `false`
+	ISODownloadPVE bool `mapstructure:"iso_download_pve"`
 	// If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 	Unmount              bool   `mapstructure:"unmount"`
 	ShouldUploadISO      bool   `mapstructure-to-hcl2:",skip"`

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -226,6 +226,7 @@ type additionalISOsConfig struct {
 	// Proxmox storage pool onto which to upload
 	// the ISO file.
 	ISOStoragePool string `mapstructure:"iso_storage_pool"`
+	ISODownloadPVE bool   `mapstructure:"iso_download_pve"`
 	// If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 	Unmount              bool   `mapstructure:"unmount"`
 	ShouldUploadISO      bool   `mapstructure-to-hcl2:",skip"`
@@ -756,6 +757,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		}
 		if options != 1 {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("one of iso_file, iso_url, or a combination of cd_files and cd_content must be specified for AdditionalISO file %s", c.AdditionalISOFiles[idx].Device))
+		}
+		if len(c.AdditionalISOFiles[idx].ISOConfig.ISOUrls) == 0 && c.AdditionalISOFiles[idx].ISOConfig.RawSingleISOUrl == "" && c.AdditionalISOFiles[idx].ISODownloadPVE {
+			err = packersdk.MultiErrorAppend(errs, fmt.Errorf("iso_download_pve can only be used together with iso_url"))
 		}
 	}
 	if c.EFIDisk != "" {

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -286,6 +286,7 @@ type FlatadditionalISOsConfig struct {
 	Device          *string           `mapstructure:"device" cty:"device" hcl:"device"`
 	ISOFile         *string           `mapstructure:"iso_file" cty:"iso_file" hcl:"iso_file"`
 	ISOStoragePool  *string           `mapstructure:"iso_storage_pool" cty:"iso_storage_pool" hcl:"iso_storage_pool"`
+	ISODownloadPVE  *bool             `mapstructure:"iso_download_pve" cty:"iso_download_pve" hcl:"iso_download_pve"`
 	Unmount         *bool             `mapstructure:"unmount" cty:"unmount" hcl:"unmount"`
 	CDFiles         []string          `mapstructure:"cd_files" cty:"cd_files" hcl:"cd_files"`
 	CDContent       map[string]string `mapstructure:"cd_content" cty:"cd_content" hcl:"cd_content"`
@@ -312,6 +313,7 @@ func (*FlatadditionalISOsConfig) HCL2Spec() map[string]hcldec.Spec {
 		"device":               &hcldec.AttrSpec{Name: "device", Type: cty.String, Required: false},
 		"iso_file":             &hcldec.AttrSpec{Name: "iso_file", Type: cty.String, Required: false},
 		"iso_storage_pool":     &hcldec.AttrSpec{Name: "iso_storage_pool", Type: cty.String, Required: false},
+		"iso_download_pve":     &hcldec.AttrSpec{Name: "iso_download_pve", Type: cty.Bool, Required: false},
 		"unmount":              &hcldec.AttrSpec{Name: "unmount", Type: cty.Bool, Required: false},
 		"cd_files":             &hcldec.AttrSpec{Name: "cd_files", Type: cty.List(cty.String), Required: false},
 		"cd_content":           &hcldec.AttrSpec{Name: "cd_content", Type: cty.Map(cty.String), Required: false},

--- a/builder/proxmox/common/step_download_iso_on_pve.go
+++ b/builder/proxmox/common/step_download_iso_on_pve.go
@@ -42,10 +42,7 @@ func Download_iso_on_pve(state multistep.StateBag, ISOUrls []string, ISOChecksum
 	for _, url := range ISOUrls {
 		var checksum string
 		var checksumType string
-		if ISOChecksum == "none" {
-			checksum = ""
-			checksumType = ""
-		} else {
+		if ISOChecksum != "none" {
 			gr := &getter.Request{
 				Src: url + "?checksum=" + ISOChecksum,
 			}

--- a/builder/proxmox/common/step_download_iso_on_pve.go
+++ b/builder/proxmox/common/step_download_iso_on_pve.go
@@ -25,6 +25,7 @@ func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag
 	var isoStoragePath string
 	isoStoragePath = Download_iso_on_pve(state, s.ISO.ISOUrls, s.ISO.ISOChecksum, s.ISO.ISOStoragePool)
 
+	// If available, set the file path to the downloaded iso file on the node
 	if isoStoragePath != "" {
 		s.ISO.ISOFile = isoStoragePath
 		return multistep.ActionContinue
@@ -33,11 +34,20 @@ func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag
 	return multistep.ActionHalt
 }
 
+// Download_iso_on_pve abstracts the checksum and download process os that the code can be shared between
+// the common module and the iso module. This is necessary because both handle the storage path to the iso differently.
+//
+// The function takes a list of URLs to download the iso and tries them one another.
+// If a download was successful it skips the additonal downlaod mirrors and returns the path to the iso on the node.
+//
+// Returns: When successful, the path to the iso on the node, else an empty string.
 func Download_iso_on_pve(state multistep.StateBag, ISOUrls []string, ISOChecksum string, ISOStoragePool string) string {
 	ui := state.Get("ui").(packersdk.Ui)
 	client := state.Get("proxmoxClient").(*proxmox.Client)
 	c := state.Get("config").(*Config)
 
+	// Generate ISOConfig configuration attributes in the format defined for packer-plugin-sdk
+	// and use go-getter to generate parameters compatible with the Proxmox-API.
 	var isoConfig proxmox.ConfigContent_Iso
 	for _, url := range ISOUrls {
 		var checksum string
@@ -68,6 +78,7 @@ func Download_iso_on_pve(state multistep.StateBag, ISOUrls []string, ISOChecksum
 
 		ui.Say(fmt.Sprintf("Beginning download of %s to node %s", isoConfig.DownloadUrl, isoConfig.Node))
 		err := proxmox.DownloadIsoFromUrl(client, isoConfig)
+		// On error continues with the next URL and logs the error
 		if err != nil {
 			state.Put("error", err)
 			ui.Error(err.Error())
@@ -75,8 +86,10 @@ func Download_iso_on_pve(state multistep.StateBag, ISOUrls []string, ISOChecksum
 		}
 		isoStoragePath := fmt.Sprintf("%s:iso/%s", isoConfig.Storage, isoConfig.Filename)
 		ui.Say(fmt.Sprintf("Finished downloading %s", isoStoragePath))
+		// Returns the path to the iso on the node
 		return isoStoragePath
 	}
+	// Returns an empty string, which means download was not successful.
 	return ""
 }
 

--- a/builder/proxmox/common/step_download_iso_on_pve.go
+++ b/builder/proxmox/common/step_download_iso_on_pve.go
@@ -1,0 +1,87 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package proxmox
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"path"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/go-getter/v2"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// stepDownloadISOOnPVE downloads an ISO file directly to the specified PVE node.
+// Checksums are also calculated and compared on the PVE node, not by Packer.
+type stepDownloadISOOnPVE struct {
+	ISO *additionalISOsConfig
+}
+
+func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	var isoStoragePath string
+	isoStoragePath = Download_iso_on_pve(state, s.ISO.ISOUrls, s.ISO.ISOChecksum, s.ISO.ISOStoragePool)
+
+	if isoStoragePath != "" {
+		s.ISO.ISOFile = isoStoragePath
+		return multistep.ActionContinue
+	}
+	// Abort if no ISO can be downloaded
+	return multistep.ActionHalt
+}
+
+func Download_iso_on_pve(state multistep.StateBag, ISOUrls []string, ISOChecksum string, ISOStoragePool string) string {
+	ui := state.Get("ui").(packersdk.Ui)
+	client := state.Get("proxmoxClient").(*proxmox.Client)
+	c := state.Get("config").(*Config)
+
+	var isoConfig proxmox.ConfigContent_Iso
+	for _, url := range ISOUrls {
+		var checksum string
+		var checksumType string
+		if ISOChecksum == "none" {
+			checksum = ""
+			checksumType = ""
+		} else {
+			gr := &getter.Request{
+				Src: url + "?checksum=" + ISOChecksum,
+			}
+			gc := getter.Client{}
+			fileChecksum, err := gc.GetChecksum(context.TODO(), gr)
+			if err != nil {
+				state.Put("error", err)
+				ui.Error(err.Error())
+				continue
+			}
+			checksum = hex.EncodeToString(fileChecksum.Value)
+			checksumType = fileChecksum.Type
+		}
+
+		isoConfig = proxmox.ConfigContent_Iso{
+			Node:              c.Node,
+			Storage:           ISOStoragePool,
+			DownloadUrl:       url,
+			Filename:          path.Base(url),
+			ChecksumAlgorithm: checksumType,
+			Checksum:          checksum,
+		}
+
+		ui.Say(fmt.Sprintf("Beginning download of %s to node %s", isoConfig.DownloadUrl, isoConfig.Node))
+		err := proxmox.DownloadIsoFromUrl(client, isoConfig)
+		if err != nil {
+			state.Put("error", err)
+			ui.Error(err.Error())
+			continue
+		}
+		isoStoragePath := fmt.Sprintf("%s:iso/%s", isoConfig.Storage, isoConfig.Filename)
+		ui.Say(fmt.Sprintf("Finished downloading %s", isoStoragePath))
+		return isoStoragePath
+	}
+	return ""
+}
+
+func (s *stepDownloadISOOnPVE) Cleanup(state multistep.StateBag) {
+}

--- a/builder/proxmox/iso/builder.go
+++ b/builder/proxmox/iso/builder.go
@@ -39,7 +39,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	preSteps := []multistep.Step{}
 	if b.config.ISODownloadPVE {
 		preSteps = append(preSteps,
-			&stepDownloadISOOnPVE{},
+			&stepDownloadISOOnPVE{
+				ISOStoragePool: b.config.ISOStoragePool,
+				ISOUrls:        b.config.ISOUrls,
+				ISOChecksum:    b.config.ISOChecksum,
+			},
 		)
 	} else {
 		preSteps = append(preSteps,

--- a/builder/proxmox/iso/config.go
+++ b/builder/proxmox/iso/config.go
@@ -26,10 +26,9 @@ type Config struct {
 	// Proxmox storage pool onto which to upload
 	// the ISO file.
 	ISOStoragePool string `mapstructure:"iso_storage_pool"`
-	// Download the specified `iso_url` directly from
-	// the PVE node. Defaults to `false`.
-	// By default Packer downloads the ISO and uploads it in a second step, this
-	// option lets Proxmox handle downloading the ISO directly from the server.
+	// Download the ISO directly from the PVE node rather than through Packer.
+	//
+	// Defaults to `false`
 	ISODownloadPVE bool `mapstructure:"iso_download_pve"`
 	// If true, remove the mounted ISO from the template
 	// after finishing. Defaults to `false`.

--- a/builder/proxmox/iso/step_download_iso_on_pve.go
+++ b/builder/proxmox/iso/step_download_iso_on_pve.go
@@ -8,7 +8,6 @@ import (
 
 	proxmoxcommon "github.com/hashicorp/packer-plugin-proxmox/builder/proxmox/common"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
 // stepDownloadISOOnPVE downloads an ISO file directly to the specified PVE node.
@@ -20,8 +19,6 @@ type stepDownloadISOOnPVE struct {
 }
 
 func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ui := state.Get("ui").(packersdk.Ui)
-
 	builderConfig := state.Get("iso-config").(*Config)
 	if !builderConfig.shouldUploadISO {
 		state.Put("iso_file", builderConfig.ISOFile)
@@ -34,7 +31,6 @@ func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag
 	// Abort if no ISO can be downloaded
 	if err != nil {
 		state.Put("error", err)
-		ui.Error("Download of iso file failed. Aborting!")
 		return multistep.ActionHalt
 	}
 	// If available, set the file path to the downloaded iso file on the node

--- a/builder/proxmox/iso/step_download_iso_on_pve.go
+++ b/builder/proxmox/iso/step_download_iso_on_pve.go
@@ -28,6 +28,7 @@ func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag
 	var isoStoragePath string
 	isoStoragePath = proxmoxcommon.Download_iso_on_pve(state, s.ISOUrls, s.ISOChecksum, s.ISOStoragePool)
 
+	// If available, set the file path to the downloaded iso file on the node
 	if isoStoragePath != "" {
 		state.Put("iso_file", isoStoragePath)
 		return multistep.ActionContinue

--- a/builder/proxmox/iso/step_download_iso_on_pve.go
+++ b/builder/proxmox/iso/step_download_iso_on_pve.go
@@ -5,44 +5,31 @@ package proxmoxiso
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/Telmate/proxmox-api-go/proxmox"
+	proxmoxcommon "github.com/hashicorp/packer-plugin-proxmox/builder/proxmox/common"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
 // stepDownloadISOOnPVE downloads an ISO file directly to the specified PVE node.
 // Checksums are also calculated and compared on the PVE node, not by Packer.
-type stepDownloadISOOnPVE struct{}
+type stepDownloadISOOnPVE struct {
+	ISOStoragePool string
+	ISOUrls        []string
+	ISOChecksum    string
+}
 
 func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ui := state.Get("ui").(packersdk.Ui)
-	client := state.Get("proxmoxClient").(*proxmox.Client)
-
 	builderConfig := state.Get("iso-config").(*Config)
-
 	if !builderConfig.shouldUploadISO {
 		state.Put("iso_file", builderConfig.ISOFile)
 		return multistep.ActionContinue
 	}
 
-	isoConfigs, err := builderConfig.generateIsoConfigs()
-	if err != nil {
-		state.Put("error", err)
-		ui.Error(err.Error())
-	}
-	for _, isoConfig := range isoConfigs {
-		ui.Say(fmt.Sprintf("Beginning download of %s to node %s", isoConfig.DownloadUrl, isoConfig.Node))
-		err := proxmox.DownloadIsoFromUrl(client, isoConfig)
-		if err != nil {
-			state.Put("error", err)
-			ui.Error(err.Error())
-			continue
-		}
-		isoStoragePath := fmt.Sprintf("%s:iso/%s", isoConfig.Storage, isoConfig.Filename)
+	var isoStoragePath string
+	isoStoragePath = proxmoxcommon.Download_iso_on_pve(state, s.ISOUrls, s.ISOChecksum, s.ISOStoragePool)
+
+	if isoStoragePath != "" {
 		state.Put("iso_file", isoStoragePath)
-		ui.Say(fmt.Sprintf("Finished downloading %s", isoStoragePath))
 		return multistep.ActionContinue
 	}
 	// Abort if no ISO can be downloaded

--- a/docs-partials/builder/proxmox/common/additionalISOsConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/additionalISOsConfig-not-required.mdx
@@ -14,6 +14,8 @@
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
+- `iso_download_pve` (bool) - ISO Download PVE
+
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/additionalISOsConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/additionalISOsConfig-not-required.mdx
@@ -14,7 +14,9 @@
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
-- `iso_download_pve` (bool) - ISO Download PVE
+- `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
+  
+  Defaults to `false`
 
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 

--- a/docs-partials/builder/proxmox/iso/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/iso/Config-not-required.mdx
@@ -8,10 +8,9 @@
 - `iso_storage_pool` (string) - Proxmox storage pool onto which to upload
   the ISO file.
 
-- `iso_download_pve` (bool) - Download the specified `iso_url` directly from
-  the PVE node. Defaults to `false`.
-  By default Packer downloads the ISO and uploads it in a second step, this
-  option lets Proxmox handle downloading the ISO directly from the server.
+- `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
+  
+  Defaults to `false`
 
 - `unmount_iso` (bool) - If true, remove the mounted ISO from the template
   after finishing. Defaults to `false`.


### PR DESCRIPTION
This PR adds the `iso_download_pve` feature to `additional_iso_files`. This is helpful for iso files that are a on the bigger side and are often used for multiple VMs, like the virtio drivers. The flag can only be used together with iso_url.
The code is based on the code from the iso module and shares it with it. 

It was tested on PVE  7.4-3.
