### PR TITLE
.gitignore: ignore crash.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 main
 dist/*
 packer-plugin-proxmox
+crash.log


### PR DESCRIPTION
The crash.log file is an artifact from testing, and should not be tracked by Git.