### PR TITLE
Remove extra line to fix formatting

### DIFF
--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -347,7 +347,6 @@ or responding to pattern `/dev/.+`. Example:
         * hdiutil (normally found in macOS)
         * oscdimg (normally found in Windows as part of the Windows ADK)
 
-
     - `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
       contents. It can be used alongside `cd_files`, which is useful to add large
       files without loading them into memory. If any paths are specified by both,


### PR DESCRIPTION
The formatting of the 'cd_content' section of the documentation is broken on the MDX interpreter on the website - it looks like the extra blank line between the two paragraphs combined with the four spaces preceding the "-" make the MDX interpreter see the block as code and not Markdown coded text.