### PR TITLE
Add support for PCI device pass through

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -104,6 +104,7 @@ type FlatConfig struct {
 	VGA                       *proxmox.FlatvgaConfig             `mapstructure:"vga" cty:"vga" hcl:"vga"`
 	NICs                      []proxmox.FlatNICConfig            `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
 	Disks                     []proxmox.FlatdiskConfig           `mapstructure:"disks" cty:"disks" hcl:"disks"`
+	PCIDevices                []proxmox.FlatpciDeviceConfig      `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                   []string                           `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                              `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController            *string                            `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
@@ -228,6 +229,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vga":                          &hcldec.BlockSpec{TypeName: "vga", Nested: hcldec.ObjectSpec((*proxmox.FlatvgaConfig)(nil).HCL2Spec())},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*proxmox.FlatNICConfig)(nil).HCL2Spec())},
 		"disks":                        &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*proxmox.FlatdiskConfig)(nil).HCL2Spec())},
+		"pci_devices":                  &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*proxmox.FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -512,6 +512,7 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		}
 	}
 
+	// See https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/hardware/pci/{pciid}
 	validPCIIDre := regexp.MustCompile(`^(?:[0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]$`)
 	for _, device := range c.PCIDevices {
 		if device.Host == "" && device.Mapping == "" {

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -199,13 +199,13 @@ type vgaConfig struct {
 //	```
 type pciDeviceConfig struct {
 	// The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
-	Host string `mapstructure:"host" required:"true"`
+	Host string `mapstructure:"host"`
 	// Override PCI device ID visible to guest.
 	DeviceID string `mapstructure:"device_id"`
 	// Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
 	LegacyIGD bool `mapstructure:"legacy_igd"`
 	// The ID of a cluster wide mapping. Either this or the `host` key must be set.
-	Mapping string `mapstructure:"mapping" required:"true"`
+	Mapping string `mapstructure:"mapping"`
 	// Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
 	PCIe bool `mapstructure:"pcie"`
 	// The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -518,6 +518,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		if device.Host == "" && device.Mapping == "" {
 			errs = packersdk.MultiErrorAppend(errs, errors.New("either the host or the mapping key must be specified"))
 		}
+		if device.Host != "" && device.Mapping != "" {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("the host and the mapping key cannot both be set"))
+		}
 		if device.Host != "" && !validPCIIDre.MatchString(device.Host) {
 			errs = packersdk.MultiErrorAppend(errs, errors.New("host contains invalid PCI ID"))
 		}

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -211,7 +211,7 @@ type pciDeviceConfig struct {
 	// The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
 	MDEV string `mapstructure:"mdev"`
 	// Specify whether or not the device’s ROM BAR will be visible in the guest’s memory map. Defaults to `false`.
-	HideROMBAR bool `mapstructure:"rombar"`
+	HideROMBAR bool `mapstructure:"hide_rombar"`
 	// Custom PCI device rom filename (must be located in `/usr/share/kvm/`).
 	ROMFile string `mapstructure:"romfile"`
 	//Override PCI subsystem device ID visible to guest.

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -181,21 +181,22 @@ type vgaConfig struct {
 //
 // Example configuration (HCL):
 //
-//	```hcl
-//	pci_devices {
-//	host          = "0000:0d:00.1"
-//	pcie          = false
-//	device_id     = "1003"
-//	legacy_igd    = false
-//	mapping       = "someNic"
-//	mdev          = "some-model"
-//	hide_rombar   = false
-//	romfile       = "vbios.bin"
-//	sub_device_id = ""
-//	sub_vendor_id = ""
-//	vendor_id     = "15B3"
-//	x_vga         = false
-//	}
+// ```hcl
+// pci_devices {
+// host          = "0000:0d:00.1"
+// pcie          = false
+// device_id     = "1003"
+// legacy_igd    = false
+// mapping       = "someNic"
+// mdev          = "some-model"
+// hide_rombar   = false
+// romfile       = "vbios.bin"
+// sub_device_id = ""
+// sub_vendor_id = ""
+// vendor_id     = "15B3"
+// x_vga         = false
+// }
+//
 //	```
 type pciDeviceConfig struct {
 	// The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -189,7 +189,7 @@ type vgaConfig struct {
 //	legacy_igd    = false
 //	mapping       = "someNic"
 //	mdev          = "some-model"
-//	rombar        = true
+//	hide_rombar   = false
 //	romfile       = "vbios.bin"
 //	sub_device_id = ""
 //	sub_vendor_id = ""

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -512,9 +512,13 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		}
 	}
 
+	validPCIIDre := regexp.MustCompile(`^(?:[0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]$`)
 	for _, device := range c.PCIDevices {
 		if device.Host == "" && device.Mapping == "" {
 			errs = packersdk.MultiErrorAppend(errs, errors.New("either the host or the mapping key must be specified"))
+		}
+		if device.Host != "" && !validPCIIDre.MatchString(device.Host) {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("host contains invalid PCI ID"))
 		}
 		if device.LegacyIGD {
 			if c.Machine != "pc" && !strings.HasPrefix(c.Machine, "pc-i440fx") {

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -171,18 +171,54 @@ type vgaConfig struct {
 	Type   string `mapstructure:"type"`
 	Memory int    `mapstructure:"memory"`
 }
+
+// - `pci_devices` (array of objects) - Passthrough a host PCI device into the VM.
+// For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+//
+// Example configuration (HCL):
+//
+// ```hcl
+//
+//	pci_devices {
+//	  host          = "0000:0d:00.1"
+//	  pcie          = false
+//	  device_id     = "1003"
+//	  legacy_igd    = false
+//	  mapping       = "someNic"
+//	  mdev          = "some-model"
+//	  rombar        = true
+//	  romfile       = "vbios.bin"
+//	  sub_device_id = ""
+//	  sub_vendor_id = ""
+//	  vendor_id     = "15B3"
+//	  x_vga         = false
+//	}
+//
+// ```
 type pciDeviceConfig struct {
-	Host        string `mapstructure:"host"`
-	DeviceID    string `mapstructure:"device_id"`
-	Mapping     string `mapstructure:"mapping"`
-	MDEV        string `mapstructure:"mdev"`
-	ROMFile     string `mapstructure:"romfile"`
+	// The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
+	Host string `mapstructure:"host" required:"true"`
+	// Override PCI device ID visible to guest.
+	DeviceID string `mapstructure:"device_id"`
+	// Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
 	LegacyIGD bool `mapstructure:"legacy_igd"`
+	// The ID of a cluster wide mapping. Either this or the `host` key must be set.
+	Mapping string `mapstructure:"mapping" required:"true"`
+	// Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
 	PCIe bool `mapstructure:"pcie"`
+	// The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
+	MDEV string `mapstructure:"mdev"`
+	// Specify whether or not the device’s ROM BAR will be visible in the guest’s memory map. Defaults to `false`.
 	HideROMBAR bool `mapstructure:"rombar"`
+	// Custom PCI device rom filename (must be located in `/usr/share/kvm/`).
+	ROMFile string `mapstructure:"romfile"`
+	//Override PCI subsystem device ID visible to guest.
 	SubDeviceID string `mapstructure:"sub_device_id"`
+	// Override PCI subsystem vendor ID visible to guest.
 	SubVendorID string `mapstructure:"sub_vendor_id"`
-	VendorID    string `mapstructure:"vendor_id"`
+	// Override PCI vendor ID visible to guest.
+	VendorID string `mapstructure:"vendor_id"`
+	// Enable vfio-vga device support. Defaults to `false`.
 	XVGA bool `mapstructure:"x_vga"`
 }
 

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -172,29 +172,31 @@ type vgaConfig struct {
 	Memory int    `mapstructure:"memory"`
 }
 
-// - `pci_devices` (array of objects) - Passthrough a host PCI device into the VM.
-// For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+// Allows passing through a host PCI device into the VM. For example, a graphics card
+// or a network adapter. Devices that are mapped into a guest VM are no longer available
+// on the host. A minimal configuration only requires either the `host` or the `mapping`
+// key to be specifed.
+//
+// Note: VMs with passed-through devices cannot be migrated.
 //
 // Example configuration (HCL):
 //
-// ```hcl
-//
+//	```hcl
 //	pci_devices {
-//	  host          = "0000:0d:00.1"
-//	  pcie          = false
-//	  device_id     = "1003"
-//	  legacy_igd    = false
-//	  mapping       = "someNic"
-//	  mdev          = "some-model"
-//	  rombar        = true
-//	  romfile       = "vbios.bin"
-//	  sub_device_id = ""
-//	  sub_vendor_id = ""
-//	  vendor_id     = "15B3"
-//	  x_vga         = false
+//	host          = "0000:0d:00.1"
+//	pcie          = false
+//	device_id     = "1003"
+//	legacy_igd    = false
+//	mapping       = "someNic"
+//	mdev          = "some-model"
+//	rombar        = true
+//	romfile       = "vbios.bin"
+//	sub_device_id = ""
+//	sub_vendor_id = ""
+//	vendor_id     = "15B3"
+//	x_vga         = false
 //	}
-//
-// ```
+//	```
 type pciDeviceConfig struct {
 	// The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
 	Host string `mapstructure:"host" required:"true"`

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -196,8 +196,7 @@ type vgaConfig struct {
 // vendor_id     = "15B3"
 // x_vga         = false
 // }
-//
-//	```
+// ```
 type pciDeviceConfig struct {
 	// The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
 	Host string `mapstructure:"host"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -384,43 +384,16 @@ func (*FlatefiConfig) HCL2Spec() map[string]hcldec.Spec {
 	return s
 }
 
-// Flatrng0Config is an auto-generated flat version of rng0Config.
-// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
-type Flatrng0Config struct {
-	Source   *string `mapstructure:"source" required:"true" cty:"source" hcl:"source"`
-	MaxBytes *int    `mapstructure:"max_bytes" required:"true" cty:"max_bytes" hcl:"max_bytes"`
-	Period   *int    `mapstructure:"period" required:"false" cty:"period" hcl:"period"`
-}
-
-// FlatMapstructure returns a new Flatrng0Config.
-// Flatrng0Config is an auto-generated flat version of rng0Config.
-// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
-func (*rng0Config) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
-	return new(Flatrng0Config)
-}
-
-// HCL2Spec returns the hcl spec of a rng0Config.
-// This spec is used by HCL to read the fields of rng0Config.
-// The decoded values from this spec will then be applied to a Flatrng0Config.
-func (*Flatrng0Config) HCL2Spec() map[string]hcldec.Spec {
-	s := map[string]hcldec.Spec{
-		"source":    &hcldec.AttrSpec{Name: "source", Type: cty.String, Required: false},
-		"max_bytes": &hcldec.AttrSpec{Name: "max_bytes", Type: cty.Number, Required: false},
-		"period":    &hcldec.AttrSpec{Name: "period", Type: cty.Number, Required: false},
-	}
-	return s
-}
-
 // FlatpciDeviceConfig is an auto-generated flat version of pciDeviceConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatpciDeviceConfig struct {
-	Host        *string `mapstructure:"host" cty:"host" hcl:"host"`
+	Host        *string `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
 	DeviceID    *string `mapstructure:"device_id" cty:"device_id" hcl:"device_id"`
 	LegacyIGD   *bool   `mapstructure:"legacy_igd" cty:"legacy_igd" hcl:"legacy_igd"`
-	Mapping     *string `mapstructure:"mapping" cty:"mapping" hcl:"mapping"`
+	Mapping     *string `mapstructure:"mapping" required:"true" cty:"mapping" hcl:"mapping"`
 	PCIe        *bool   `mapstructure:"pcie" cty:"pcie" hcl:"pcie"`
 	MDEV        *string `mapstructure:"mdev" cty:"mdev" hcl:"mdev"`
-	ROMBar      *bool   `mapstructure:"rombar" cty:"rombar" hcl:"rombar"`
+	HideROMBAR  *bool   `mapstructure:"rombar" cty:"rombar" hcl:"rombar"`
 	ROMFile     *string `mapstructure:"romfile" cty:"romfile" hcl:"romfile"`
 	SubDeviceID *string `mapstructure:"sub_device_id" cty:"sub_device_id" hcl:"sub_device_id"`
 	SubVendorID *string `mapstructure:"sub_vendor_id" cty:"sub_vendor_id" hcl:"sub_vendor_id"`
@@ -452,6 +425,33 @@ func (*FlatpciDeviceConfig) HCL2Spec() map[string]hcldec.Spec {
 		"sub_vendor_id": &hcldec.AttrSpec{Name: "sub_vendor_id", Type: cty.String, Required: false},
 		"vendor_id":     &hcldec.AttrSpec{Name: "vendor_id", Type: cty.String, Required: false},
 		"x_vga":         &hcldec.AttrSpec{Name: "x_vga", Type: cty.Bool, Required: false},
+	}
+	return s
+}
+
+// Flatrng0Config is an auto-generated flat version of rng0Config.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type Flatrng0Config struct {
+	Source   *string `mapstructure:"source" required:"true" cty:"source" hcl:"source"`
+	MaxBytes *int    `mapstructure:"max_bytes" required:"true" cty:"max_bytes" hcl:"max_bytes"`
+	Period   *int    `mapstructure:"period" required:"false" cty:"period" hcl:"period"`
+}
+
+// FlatMapstructure returns a new Flatrng0Config.
+// Flatrng0Config is an auto-generated flat version of rng0Config.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*rng0Config) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(Flatrng0Config)
+}
+
+// HCL2Spec returns the hcl spec of a rng0Config.
+// This spec is used by HCL to read the fields of rng0Config.
+// The decoded values from this spec will then be applied to a Flatrng0Config.
+func (*Flatrng0Config) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"source":    &hcldec.AttrSpec{Name: "source", Type: cty.String, Required: false},
+		"max_bytes": &hcldec.AttrSpec{Name: "max_bytes", Type: cty.Number, Required: false},
+		"period":    &hcldec.AttrSpec{Name: "period", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -387,10 +387,10 @@ func (*FlatefiConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatpciDeviceConfig is an auto-generated flat version of pciDeviceConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatpciDeviceConfig struct {
-	Host        *string `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
+	Host        *string `mapstructure:"host" cty:"host" hcl:"host"`
 	DeviceID    *string `mapstructure:"device_id" cty:"device_id" hcl:"device_id"`
 	LegacyIGD   *bool   `mapstructure:"legacy_igd" cty:"legacy_igd" hcl:"legacy_igd"`
-	Mapping     *string `mapstructure:"mapping" required:"true" cty:"mapping" hcl:"mapping"`
+	Mapping     *string `mapstructure:"mapping" cty:"mapping" hcl:"mapping"`
 	PCIe        *bool   `mapstructure:"pcie" cty:"pcie" hcl:"pcie"`
 	MDEV        *string `mapstructure:"mdev" cty:"mdev" hcl:"mdev"`
 	HideROMBAR  *bool   `mapstructure:"hide_rombar" cty:"hide_rombar" hcl:"hide_rombar"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -103,6 +103,7 @@ type FlatConfig struct {
 	VGA                       *FlatvgaConfig             `mapstructure:"vga" cty:"vga" hcl:"vga"`
 	NICs                      []FlatNICConfig            `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
 	Disks                     []FlatdiskConfig           `mapstructure:"disks" cty:"disks" hcl:"disks"`
+	PCIDevices                []FlatpciDeviceConfig      `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                   []string                   `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                      `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController            *string                    `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
@@ -221,6 +222,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vga":                          &hcldec.BlockSpec{TypeName: "vga", Nested: hcldec.ObjectSpec((*FlatvgaConfig)(nil).HCL2Spec())},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNICConfig)(nil).HCL2Spec())},
 		"disks":                        &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*FlatdiskConfig)(nil).HCL2Spec())},
+		"pci_devices":                  &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
@@ -405,6 +407,51 @@ func (*Flatrng0Config) HCL2Spec() map[string]hcldec.Spec {
 		"source":    &hcldec.AttrSpec{Name: "source", Type: cty.String, Required: false},
 		"max_bytes": &hcldec.AttrSpec{Name: "max_bytes", Type: cty.Number, Required: false},
 		"period":    &hcldec.AttrSpec{Name: "period", Type: cty.Number, Required: false},
+	}
+	return s
+}
+
+// FlatpciDeviceConfig is an auto-generated flat version of pciDeviceConfig.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatpciDeviceConfig struct {
+	Host        *string `mapstructure:"host" cty:"host" hcl:"host"`
+	DeviceID    *string `mapstructure:"device_id" cty:"device_id" hcl:"device_id"`
+	LegacyIGD   *bool   `mapstructure:"legacy_igd" cty:"legacy_igd" hcl:"legacy_igd"`
+	Mapping     *string `mapstructure:"mapping" cty:"mapping" hcl:"mapping"`
+	PCIe        *bool   `mapstructure:"pcie" cty:"pcie" hcl:"pcie"`
+	MDEV        *string `mapstructure:"mdev" cty:"mdev" hcl:"mdev"`
+	ROMBar      *bool   `mapstructure:"rombar" cty:"rombar" hcl:"rombar"`
+	ROMFile     *string `mapstructure:"romfile" cty:"romfile" hcl:"romfile"`
+	SubDeviceID *string `mapstructure:"sub_device_id" cty:"sub_device_id" hcl:"sub_device_id"`
+	SubVendorID *string `mapstructure:"sub_vendor_id" cty:"sub_vendor_id" hcl:"sub_vendor_id"`
+	VendorID    *string `mapstructure:"vendor_id" cty:"vendor_id" hcl:"vendor_id"`
+	XVGA        *bool   `mapstructure:"x_vga" cty:"x_vga" hcl:"x_vga"`
+}
+
+// FlatMapstructure returns a new FlatpciDeviceConfig.
+// FlatpciDeviceConfig is an auto-generated flat version of pciDeviceConfig.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*pciDeviceConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatpciDeviceConfig)
+}
+
+// HCL2Spec returns the hcl spec of a pciDeviceConfig.
+// This spec is used by HCL to read the fields of pciDeviceConfig.
+// The decoded values from this spec will then be applied to a FlatpciDeviceConfig.
+func (*FlatpciDeviceConfig) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"host":          &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
+		"device_id":     &hcldec.AttrSpec{Name: "device_id", Type: cty.String, Required: false},
+		"legacy_igd":    &hcldec.AttrSpec{Name: "legacy_igd", Type: cty.Bool, Required: false},
+		"mapping":       &hcldec.AttrSpec{Name: "mapping", Type: cty.String, Required: false},
+		"pcie":          &hcldec.AttrSpec{Name: "pcie", Type: cty.Bool, Required: false},
+		"mdev":          &hcldec.AttrSpec{Name: "mdev", Type: cty.String, Required: false},
+		"rombar":        &hcldec.AttrSpec{Name: "rombar", Type: cty.Bool, Required: false},
+		"romfile":       &hcldec.AttrSpec{Name: "romfile", Type: cty.String, Required: false},
+		"sub_device_id": &hcldec.AttrSpec{Name: "sub_device_id", Type: cty.String, Required: false},
+		"sub_vendor_id": &hcldec.AttrSpec{Name: "sub_vendor_id", Type: cty.String, Required: false},
+		"vendor_id":     &hcldec.AttrSpec{Name: "vendor_id", Type: cty.String, Required: false},
+		"x_vga":         &hcldec.AttrSpec{Name: "x_vga", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -393,7 +393,7 @@ type FlatpciDeviceConfig struct {
 	Mapping     *string `mapstructure:"mapping" required:"true" cty:"mapping" hcl:"mapping"`
 	PCIe        *bool   `mapstructure:"pcie" cty:"pcie" hcl:"pcie"`
 	MDEV        *string `mapstructure:"mdev" cty:"mdev" hcl:"mdev"`
-	HideROMBAR  *bool   `mapstructure:"rombar" cty:"rombar" hcl:"rombar"`
+	HideROMBAR  *bool   `mapstructure:"hide_rombar" cty:"hide_rombar" hcl:"hide_rombar"`
 	ROMFile     *string `mapstructure:"romfile" cty:"romfile" hcl:"romfile"`
 	SubDeviceID *string `mapstructure:"sub_device_id" cty:"sub_device_id" hcl:"sub_device_id"`
 	SubVendorID *string `mapstructure:"sub_vendor_id" cty:"sub_vendor_id" hcl:"sub_vendor_id"`
@@ -419,7 +419,7 @@ func (*FlatpciDeviceConfig) HCL2Spec() map[string]hcldec.Spec {
 		"mapping":       &hcldec.AttrSpec{Name: "mapping", Type: cty.String, Required: false},
 		"pcie":          &hcldec.AttrSpec{Name: "pcie", Type: cty.Bool, Required: false},
 		"mdev":          &hcldec.AttrSpec{Name: "mdev", Type: cty.String, Required: false},
-		"rombar":        &hcldec.AttrSpec{Name: "rombar", Type: cty.Bool, Required: false},
+		"hide_rombar":   &hcldec.AttrSpec{Name: "hide_rombar", Type: cty.Bool, Required: false},
 		"romfile":       &hcldec.AttrSpec{Name: "romfile", Type: cty.String, Required: false},
 		"sub_device_id": &hcldec.AttrSpec{Name: "sub_device_id", Type: cty.String, Required: false},
 		"sub_vendor_id": &hcldec.AttrSpec{Name: "sub_vendor_id", Type: cty.String, Required: false},

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -521,7 +521,7 @@ func TestPCIDeviceMapping(t *testing.T) {
 			device["mapping"] = tc.pciDeviceConfig.Mapping
 			device["pcie"] = tc.pciDeviceConfig.PCIe
 			device["mdev"] = tc.pciDeviceConfig.MDEV
-			device["rombar"] = tc.pciDeviceConfig.HideROMBAR
+			device["hide_rombar"] = tc.pciDeviceConfig.HideROMBAR
 			device["romfile"] = tc.pciDeviceConfig.ROMFile
 			device["sub_device_id"] = tc.pciDeviceConfig.SubDeviceID
 			device["sub_vendor_id"] = tc.pciDeviceConfig.SubVendorID

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -435,6 +435,13 @@ func TestPCIDeviceMapping(t *testing.T) {
 			expectedError: fmt.Errorf("either the host or the mapping key must be specified"),
 		},
 		{
+			expectedError: fmt.Errorf("the host and the mapping key cannot both be set"),
+			pciDeviceConfig: pciDeviceConfig{
+				Host:    "0000:03:00.0",
+				Mapping: "someNic",
+			},
+		},
+		{
 			expectedError: fmt.Errorf("host contains invalid PCI ID"),
 			pciDeviceConfig: pciDeviceConfig{
 				Host: "invalid-pci-id",

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -452,13 +452,13 @@ func TestPCIDeviceMapping(t *testing.T) {
 		{
 			expectedToFail: true,
 			pciDeviceConfig: pciDeviceConfig{
-				LegacyIGD: boolPtr(true),
+				LegacyIGD: true,
 			},
 		},
 		{
 			expectedToFail: true,
 			pciDeviceConfig: pciDeviceConfig{
-				LegacyIGD: boolPtr(true),
+				LegacyIGD: true,
 			},
 			machine: "pc",
 		},
@@ -466,7 +466,7 @@ func TestPCIDeviceMapping(t *testing.T) {
 			expectedToFail: true,
 			pciDeviceConfig: pciDeviceConfig{
 				Host:      "0000:03:00.0",
-				LegacyIGD: boolPtr(true),
+				LegacyIGD: true,
 			},
 			machine: "pc",
 			vga: vgaConfig{
@@ -477,7 +477,7 @@ func TestPCIDeviceMapping(t *testing.T) {
 			expectedToFail: false,
 			pciDeviceConfig: pciDeviceConfig{
 				Host:      "0000:03:00.0",
-				LegacyIGD: boolPtr(true),
+				LegacyIGD: true,
 			},
 			machine: "pc",
 			vga: vgaConfig{
@@ -489,7 +489,7 @@ func TestPCIDeviceMapping(t *testing.T) {
 			expectedToFail: true,
 			pciDeviceConfig: pciDeviceConfig{
 				Host: "0000:03:00.0",
-				PCIe: boolPtr(true),
+				PCIe: true,
 			},
 			machine: "pc",
 		},
@@ -497,7 +497,7 @@ func TestPCIDeviceMapping(t *testing.T) {
 			expectedToFail: false,
 			pciDeviceConfig: pciDeviceConfig{
 				Host: "0000:03:00.0",
-				PCIe: boolPtr(true),
+				PCIe: true,
 			},
 			machine: "q35",
 		},
@@ -505,7 +505,7 @@ func TestPCIDeviceMapping(t *testing.T) {
 			expectedToFail: false,
 			pciDeviceConfig: pciDeviceConfig{
 				Host: "0000:03:00.0",
-				PCIe: boolPtr(true),
+				PCIe: true,
 			},
 			machine: "pc-q35",
 		},
@@ -520,7 +520,7 @@ func TestPCIDeviceMapping(t *testing.T) {
 			device["mapping"] = tc.pciDeviceConfig.Mapping
 			device["pcie"] = tc.pciDeviceConfig.PCIe
 			device["mdev"] = tc.pciDeviceConfig.MDEV
-			device["rombar"] = tc.pciDeviceConfig.ROMBar
+			device["rombar"] = tc.pciDeviceConfig.HideROMBAR
 			device["romfile"] = tc.pciDeviceConfig.ROMFile
 			device["sub_device_id"] = tc.pciDeviceConfig.SubDeviceID
 			device["sub_vendor_id"] = tc.pciDeviceConfig.SubVendorID

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -302,16 +302,17 @@ func generateProxmoxPCIDeviceMap(devices []pciDeviceConfig) proxmox.QemuDevices 
 		devs[idx] = make(proxmox.QemuDevice)
 		setDeviceParamIfDefined(devs[idx], "host", devices[idx].Host)
 		setDeviceParamIfDefined(devs[idx], "device-id", devices[idx].DeviceID)
-		setDeviceParamIfDefined(devs[idx], "legacy-igd", strconv.FormatBool(devices[idx].LegacyIGD))
 		setDeviceParamIfDefined(devs[idx], "mapping", devices[idx].Mapping)
 		setDeviceParamIfDefined(devs[idx], "mdev", devices[idx].MDEV)
-		setDeviceParamIfDefined(devs[idx], "pcie", strconv.FormatBool(devices[idx].PCIe))
-		setDeviceParamIfDefined(devs[idx], "rombar", strconv.FormatBool(!devices[idx].HideROMBAR))
 		setDeviceParamIfDefined(devs[idx], "romfile", devices[idx].ROMFile)
 		setDeviceParamIfDefined(devs[idx], "sub-device-id", devices[idx].SubDeviceID)
 		setDeviceParamIfDefined(devs[idx], "sub-vendor-id", devices[idx].SubVendorID)
 		setDeviceParamIfDefined(devs[idx], "vendor-id", devices[idx].VendorID)
-		setDeviceParamIfDefined(devs[idx], "x-vga", strconv.FormatBool(devices[idx].XVGA))
+
+		devs[idx]["pcie"] = strconv.FormatBool(devices[idx].PCIe)
+		devs[idx]["rombar"] = strconv.FormatBool(!devices[idx].HideROMBAR)
+		devs[idx]["x-vga"] = strconv.FormatBool(devices[idx].XVGA)
+		devs[idx]["legacy-igd"] = strconv.FormatBool(devices[idx].LegacyIGD)
 	}
 	return devs
 }

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -306,7 +306,7 @@ func generateProxmoxPCIDeviceMap(devices []pciDeviceConfig) proxmox.QemuDevices 
 		setDeviceParamIfDefined(devs[idx], "mapping", devices[idx].Mapping)
 		setDeviceParamIfDefined(devs[idx], "mdev", devices[idx].MDEV)
 		setDeviceParamIfDefined(devs[idx], "pcie", strconv.FormatBool(devices[idx].PCIe))
-		setDeviceParamIfDefined(devs[idx], "rombar", strconv.FormatBool(devices[idx].HideROMBAR))
+		setDeviceParamIfDefined(devs[idx], "rombar", strconv.FormatBool(!devices[idx].HideROMBAR))
 		setDeviceParamIfDefined(devs[idx], "romfile", devices[idx].ROMFile)
 		setDeviceParamIfDefined(devs[idx], "sub-device-id", devices[idx].SubDeviceID)
 		setDeviceParamIfDefined(devs[idx], "sub-vendor-id", devices[idx].SubVendorID)

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -302,16 +302,16 @@ func generateProxmoxPCIDeviceMap(devices []pciDeviceConfig) proxmox.QemuDevices 
 		devs[idx] = make(proxmox.QemuDevice)
 		setDeviceParamIfDefined(devs[idx], "host", devices[idx].Host)
 		setDeviceParamIfDefined(devs[idx], "device-id", devices[idx].DeviceID)
-		setDeviceParamIfDefined(devs[idx], "legacy-igd", formatBoolPointer(devices[idx].LegacyIGD))
+		setDeviceParamIfDefined(devs[idx], "legacy-igd", strconv.FormatBool(devices[idx].LegacyIGD))
 		setDeviceParamIfDefined(devs[idx], "mapping", devices[idx].Mapping)
 		setDeviceParamIfDefined(devs[idx], "mdev", devices[idx].MDEV)
-		setDeviceParamIfDefined(devs[idx], "pcie", formatBoolPointer(devices[idx].PCIe))
-		setDeviceParamIfDefined(devs[idx], "rombar", formatBoolPointer(devices[idx].ROMBar))
+		setDeviceParamIfDefined(devs[idx], "pcie", strconv.FormatBool(devices[idx].PCIe))
+		setDeviceParamIfDefined(devs[idx], "rombar", strconv.FormatBool(devices[idx].HideROMBAR))
 		setDeviceParamIfDefined(devs[idx], "romfile", devices[idx].ROMFile)
 		setDeviceParamIfDefined(devs[idx], "sub-device-id", devices[idx].SubDeviceID)
 		setDeviceParamIfDefined(devs[idx], "sub-vendor-id", devices[idx].SubVendorID)
 		setDeviceParamIfDefined(devs[idx], "vendor-id", devices[idx].VendorID)
-		setDeviceParamIfDefined(devs[idx], "x-vga", formatBoolPointer(devices[idx].XVGA))
+		setDeviceParamIfDefined(devs[idx], "x-vga", strconv.FormatBool(devices[idx].XVGA))
 	}
 	return devs
 }
@@ -362,13 +362,6 @@ func generateProxmoxEfi(efi efiConfig) proxmox.QemuDevice {
 		}
 	}
 	return dev
-}
-
-func formatBoolPointer(v *bool) string {
-	if v == nil {
-		return ""
-	}
-	return strconv.FormatBool(*v)
 }
 
 func setDeviceParamIfDefined(dev proxmox.QemuDevice, key, value string) {

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -104,6 +104,7 @@ type FlatConfig struct {
 	VGA                       *proxmox.FlatvgaConfig             `mapstructure:"vga" cty:"vga" hcl:"vga"`
 	NICs                      []proxmox.FlatNICConfig            `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
 	Disks                     []proxmox.FlatdiskConfig           `mapstructure:"disks" cty:"disks" hcl:"disks"`
+	PCIDevices                []proxmox.FlatpciDeviceConfig      `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                   []string                           `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                              `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController            *string                            `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
@@ -231,6 +232,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vga":                          &hcldec.BlockSpec{TypeName: "vga", Nested: hcldec.ObjectSpec((*proxmox.FlatvgaConfig)(nil).HCL2Spec())},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*proxmox.FlatNICConfig)(nil).HCL2Spec())},
 		"disks":                        &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*proxmox.FlatdiskConfig)(nil).HCL2Spec())},
+		"pci_devices":                  &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*proxmox.FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -54,6 +54,8 @@
 
 - `disks` ([]diskConfig) - Disks
 
+- `pci_devices` ([]pciDeviceConfig) - PCI Devices
+
 - `serials` ([]string) - Serials
 
 - `qemu_agent` (boolean) - Agent

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig-not-required.mdx
@@ -1,0 +1,23 @@
+<!-- Code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `device_id` (string) - Override PCI device ID visible to guest.
+
+- `legacy_igd` (bool) - Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
+
+- `pcie` (bool) - Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
+
+- `mdev` (string) - The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
+
+- `rombar` (bool) - Specify whether or not the device’s ROM BAR will be visible in the guest’s memory map. Defaults to `false`.
+
+- `romfile` (string) - Custom PCI device rom filename (must be located in `/usr/share/kvm/`).
+
+- `sub_device_id` (string) - Override PCI subsystem device ID visible to guest.
+
+- `sub_vendor_id` (string) - Override PCI subsystem vendor ID visible to guest.
+
+- `vendor_id` (string) - Override PCI vendor ID visible to guest.
+
+- `x_vga` (bool) - Enable vfio-vga device support. Defaults to `false`.
+
+<!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig-not-required.mdx
@@ -8,7 +8,7 @@
 
 - `mdev` (string) - The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
 
-- `rombar` (bool) - Specify whether or not the device’s ROM BAR will be visible in the guest’s memory map. Defaults to `false`.
+- `hide_rombar` (bool) - Specify whether or not the device’s ROM BAR will be visible in the guest’s memory map. Defaults to `false`.
 
 - `romfile` (string) - Custom PCI device rom filename (must be located in `/usr/share/kvm/`).
 

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig-not-required.mdx
@@ -1,8 +1,12 @@
 <!-- Code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
+- `host` (string) - The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
+
 - `device_id` (string) - Override PCI device ID visible to guest.
 
 - `legacy_igd` (bool) - Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
+
+- `mapping` (string) - The ID of a cluster wide mapping. Either this or the `host` key must be set.
 
 - `pcie` (bool) - Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
 

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig-required.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig-required.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
+
+- `mapping` (string) - The ID of a cluster wide mapping. Either this or the `host` key must be set.
+
+<!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig-required.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig-required.mdx
@@ -1,7 +1,0 @@
-<!-- Code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
-
-- `host` (string) - The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
-
-- `mapping` (string) - The ID of a cluster wide mapping. Either this or the `host` key must be set.
-
-<!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
@@ -17,7 +17,7 @@ Example configuration (HCL):
 	legacy_igd    = false
 	mapping       = "someNic"
 	mdev          = "some-model"
-	rombar        = true
+	hide_rombar   = false
 	romfile       = "vbios.bin"
 	sub_device_id = ""
 	sub_vendor_id = ""

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
@@ -9,21 +9,22 @@ Note: VMs with passed-through devices cannot be migrated.
 
 Example configuration (HCL):
 
-	```hcl
-	pci_devices {
-	host          = "0000:0d:00.1"
-	pcie          = false
-	device_id     = "1003"
-	legacy_igd    = false
-	mapping       = "someNic"
-	mdev          = "some-model"
-	hide_rombar   = false
-	romfile       = "vbios.bin"
-	sub_device_id = ""
-	sub_vendor_id = ""
-	vendor_id     = "15B3"
-	x_vga         = false
-	}
+```hcl
+pci_devices {
+host          = "0000:0d:00.1"
+pcie          = false
+device_id     = "1003"
+legacy_igd    = false
+mapping       = "someNic"
+mdev          = "some-model"
+hide_rombar   = false
+romfile       = "vbios.bin"
+sub_device_id = ""
+sub_vendor_id = ""
+vendor_id     = "15B3"
+x_vga         = false
+}
+
 	```
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
@@ -24,7 +24,6 @@ sub_vendor_id = ""
 vendor_id     = "15B3"
 x_vga         = false
 }
-
-	```
+```
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
@@ -1,0 +1,27 @@
+<!-- Code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `pci_devices` (array of objects) - Passthrough a host PCI device into the VM.
+For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+
+Example configuration (HCL):
+
+```hcl
+
+	pci_devices {
+	  host          = "0000:0d:00.1"
+	  pcie          = false
+	  device_id     = "1003"
+	  legacy_igd    = false
+	  mapping       = "someNic"
+	  mdev          = "some-model"
+	  rombar        = true
+	  romfile       = "vbios.bin"
+	  sub_device_id = ""
+	  sub_vendor_id = ""
+	  vendor_id     = "15B3"
+	  x_vga         = false
+	}
+
+```
+
+<!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
+++ b/docs-partials/builder/proxmox/common/pciDeviceConfig.mdx
@@ -1,27 +1,29 @@
 <!-- Code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
-- `pci_devices` (array of objects) - Passthrough a host PCI device into the VM.
-For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+Allows passing through a host PCI device into the VM. For example, a graphics card
+or a network adapter. Devices that are mapped into a guest VM are no longer available
+on the host. A minimal configuration only requires either the `host` or the `mapping`
+key to be specifed.
+
+Note: VMs with passed-through devices cannot be migrated.
 
 Example configuration (HCL):
 
-```hcl
-
+	```hcl
 	pci_devices {
-	  host          = "0000:0d:00.1"
-	  pcie          = false
-	  device_id     = "1003"
-	  legacy_igd    = false
-	  mapping       = "someNic"
-	  mdev          = "some-model"
-	  rombar        = true
-	  romfile       = "vbios.bin"
-	  sub_device_id = ""
-	  sub_vendor_id = ""
-	  vendor_id     = "15B3"
-	  x_vga         = false
+	host          = "0000:0d:00.1"
+	pcie          = false
+	device_id     = "1003"
+	legacy_igd    = false
+	mapping       = "someNic"
+	mdev          = "some-model"
+	rombar        = true
+	romfile       = "vbios.bin"
+	sub_device_id = ""
+	sub_vendor_id = ""
+	vendor_id     = "15B3"
+	x_vga         = false
 	}
-
-```
+	```
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -386,10 +386,6 @@ or responding to pattern `/dev/.+`. Example:
 
 @include 'builder/proxmox/common/pciDeviceConfig.mdx'
 
-#### Required:
-
-@include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
-
 #### Optional:
 
 @include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -236,50 +236,15 @@ or responding to pattern `/dev/.+`. Example:
   - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
     rather than a rotational disk.
 
-- `pci_devices` (array of objects) - Passthrough a host PCI device into the VM. For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+@include 'builder/proxmox/common/pciDeviceConfig.mdx'
 
-  Example configuration (HCL):
+##### Required:
 
-  ```hcl
-  pci_devices {
-    host          = "0000:0d:00.1"
-    pcie          = false
-    device_id     = "1003"
-    legacy_igd    = false
-    mapping       = "someNic"
-    mdev          = "some-model"
-    rombar        = true
-    romfile       = "vbios.bin"
-    sub_device_id = ""
-    sub_vendor_id = ""
-    vendor_id     = "15B3"
-    x_vga         = false
-  }
-  ```
+  @include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
 
-  - `host` (string) - The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
+##### Optional:
 
-  - `mapping` (string) - The ID of a cluster wide mapping. Either this or the `host` key must be set. 
-
-  - `pcie` (bool) - Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
-
-  - `device_id` (string) - Override PCI device ID visible to guest.
-
-  - `legacy_igd` (bool) - Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
-
-  - `mdev` (string) - The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
-
-  - `rombar` (bool) - Specify whether or not the device’s ROM will be visible in the guest’s memory map. Defaults to `true`.
-
-  - `romfile` (string) - Custom PCI device rom filename (must be located in `/usr/share/kvm/`). 
-
-  - `sub_device_id` (string) - Override PCI subsystem device ID visible to guest.
-
-  - `sub_vendor_id` (string) - Override PCI subsystem vendor ID visible to guest.
-
-  - `vendor_id` (string) - Override PCI vendor ID visible to guest.
-
-  - `x_vga` (bool) - Enable vfio-vga device support. Defaults to `false`.
+  @include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'
 
 - `template_name` (string) - Name of the template. Defaults to the generated
   name used during creation.

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -368,18 +368,17 @@ or responding to pattern `/dev/.+`. Example:
 
 - `machine` - (string) - Set the machine type. Supported values are 'pc' or 'q35'.
 
-#### VirtIO RNG device
+### VirtIO RNG device
 
 @include 'builder/proxmox/common/rng0Config.mdx'
 
-##### Required:
+#### Required:
 
 @include 'builder/proxmox/common/rng0Config-required.mdx'
 
-##### Optional:
+#### Optional:
 
 @include 'builder/proxmox/common/rng0Config-not-required.mdx'
-
 
 ### PCI devices
 

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -33,12 +33,14 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
-In addition to the items listed here, you will want to look at the general
-configuration references for
-[VirtIO RNG device](#virtio-rng-device),
-[PCI Devices](#pci-devices),
-and [Communicator](/packer/docs/templates/legacy_json_templates/communicator)
+You may also want to take look at the general configuration references for
+[VirtIO RNG device](#virtio-rng-device)
+and [PCI Devices](#pci-devices)
 configuration references, which can be found further down the page.
+
+In addition to the options listed here, a
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
+builder.
 
 If no communicator is defined, an SSH key is generated for use, and is used
 in the image's Cloud-Init settings for provisioning.

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -33,9 +33,12 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
-In addition to the options listed here, a
-[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
-builder.
+In addition to the items listed here, you will want to look at the general
+configuration references for
+[VirtIO RNG device](#virtio-rng-device),
+[PCI Devices](#pci-devices),
+and [Communicator](/packer/docs/templates/legacy_json_templates/communicator)
+configuration references, which can be found further down the page.
 
 If no communicator is defined, an SSH key is generated for use, and is used
 in the image's Cloud-Init settings for provisioning.
@@ -236,16 +239,6 @@ or responding to pattern `/dev/.+`. Example:
   - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
     rather than a rotational disk.
 
-@include 'builder/proxmox/common/pciDeviceConfig.mdx'
-
-##### Required:
-
-  @include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
-
-##### Optional:
-
-  @include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'
-
 - `template_name` (string) - Name of the template. Defaults to the generated
   name used during creation.
 
@@ -386,6 +379,19 @@ or responding to pattern `/dev/.+`. Example:
 ##### Optional:
 
 @include 'builder/proxmox/common/rng0Config-not-required.mdx'
+
+
+### PCI devices
+
+@include 'builder/proxmox/common/pciDeviceConfig.mdx'
+
+#### Required:
+
+@include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
+
+#### Optional:
+
+@include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'
 
 ## Example: Cloud-Init enabled Debian
 

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -236,6 +236,51 @@ or responding to pattern `/dev/.+`. Example:
   - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
     rather than a rotational disk.
 
+- `pci_devices` (array of objects) - Passthrough a host PCI device into the VM. For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+
+  Example configuration (HCL):
+
+  ```hcl
+  pci_devices {
+    host          = "0000:0d:00.1"
+    pcie          = false
+    device_id     = "1003"
+    legacy_igd    = false
+    mapping       = "someNic"
+    mdev          = "some-model"
+    rombar        = true
+    romfile       = "vbios.bin"
+    sub_device_id = ""
+    sub_vendor_id = ""
+    vendor_id     = "15B3"
+    x_vga         = false
+  }
+  ```
+
+  - `host` (string) - The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
+
+  - `mapping` (string) - The ID of a cluster wide mapping. Either this or the `host` key must be set. 
+
+  - `pcie` (bool) - Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
+
+  - `device_id` (string) - Override PCI device ID visible to guest.
+
+  - `legacy_igd` (bool) - Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
+
+  - `mdev` (string) - The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
+
+  - `rombar` (bool) - Specify whether or not the device’s ROM will be visible in the guest’s memory map. Defaults to `true`.
+
+  - `romfile` (string) - Custom PCI device rom filename (must be located in `/usr/share/kvm/`). 
+
+  - `sub_device_id` (string) - Override PCI subsystem device ID visible to guest.
+
+  - `sub_vendor_id` (string) - Override PCI subsystem vendor ID visible to guest.
+
+  - `vendor_id` (string) - Override PCI vendor ID visible to guest.
+
+  - `x_vga` (bool) - Enable vfio-vga device support. Defaults to `false`.
+
 - `template_name` (string) - Name of the template. Defaults to the generated
   name used during creation.
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -247,6 +247,51 @@ or responding to pattern `/dev/.+`. Example:
   - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
     rather than a rotational disk.
 
+- `pci_devices` (array of objects) - Passthrough a host PCI device into the VM. For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+
+  Example configuration (HCL):
+
+  ```hcl
+  pci_devices {
+    host          = "0000:0d:00.1"
+    pcie          = false
+    device_id     = "1003"
+    legacy_igd    = false
+    mapping       = "someNic"
+    mdev          = "some-model"
+    rombar        = true
+    romfile       = "vbios.bin"
+    sub_device_id = ""
+    sub_vendor_id = ""
+    vendor_id     = "15B3"
+    x_vga         = false
+  }
+  ```
+
+  - `host` (string) - The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
+
+  - `mapping` (string) - The ID of a cluster wide mapping. Either this or the `host` key must be set. 
+
+  - `pcie` (bool) - Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
+
+  - `device_id` (string) - Override PCI device ID visible to guest.
+
+  - `legacy_igd` (bool) - Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
+
+  - `mdev` (string) - The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
+
+  - `rombar` (bool) - Specify whether or not the device’s ROM will be visible in the guest’s memory map. Defaults to `true`.
+
+  - `romfile` (string) - Custom PCI device rom filename (must be located in `/usr/share/kvm/`). 
+
+  - `sub_device_id` (string) - Override PCI subsystem device ID visible to guest.
+
+  - `sub_vendor_id` (string) - Override PCI subsystem vendor ID visible to guest.
+
+  - `vendor_id` (string) - Override PCI vendor ID visible to guest.
+
+  - `x_vga` (bool) - Enable vfio-vga device support. Defaults to `false`.
+
 - `template_name` (string) - Name of the template. Defaults to the generated
   name used during creation.
 
@@ -310,6 +355,7 @@ or responding to pattern `/dev/.+`. Example:
   - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
   ### Optional
+
     - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
       booted. This can include either files or directories; any directories
       will be copied onto the CD recursively, preserving directory structure

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -29,9 +29,12 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
-In addition to the options listed here, a
-[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
-builder.
+In addition to the items listed here, you will want to look at the general
+configuration references for
+[VirtIO RNG device](#virtio-rng-device),
+[PCI Devices](#pci-devices),
+and [Communicator](/packer/docs/templates/legacy_json_templates/communicator)
+configuration references, which can be found further down the page.
 
 If no communicator is defined, an SSH key is generated for use, and is used
 in the image's Cloud-Init settings for provisioning.
@@ -247,13 +250,6 @@ or responding to pattern `/dev/.+`. Example:
   - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
     rather than a rotational disk.
 
-@include 'builder/proxmox/common/pciDeviceConfig.mdx'
-##### Required:
-
-  @include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
-##### Optional:
-
-  @include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'
 - `template_name` (string) - Name of the template. Defaults to the generated
   name used during creation.
 
@@ -428,6 +424,18 @@ or responding to pattern `/dev/.+`. Example:
 ##### Optional:
 
 @include 'builder/proxmox/common/rng0Config-not-required.mdx'
+
+### PCI devices
+
+@include 'builder/proxmox/common/pciDeviceConfig.mdx'
+
+#### Required:
+
+@include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
+
+#### Optional:
+
+@include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'
 
 ## Boot Command
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -247,50 +247,15 @@ or responding to pattern `/dev/.+`. Example:
   - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
     rather than a rotational disk.
 
-- `pci_devices` (array of objects) - Passthrough a host PCI device into the VM. For example, a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host. A minimal configuration only requires either the `host` or the `mapping` key to be specifed. Note: VMs with passed-through devices cannot be migrated.
+@include 'builder/proxmox/common/pciDeviceConfig.mdx'
 
-  Example configuration (HCL):
+##### Required:
 
-  ```hcl
-  pci_devices {
-    host          = "0000:0d:00.1"
-    pcie          = false
-    device_id     = "1003"
-    legacy_igd    = false
-    mapping       = "someNic"
-    mdev          = "some-model"
-    rombar        = true
-    romfile       = "vbios.bin"
-    sub_device_id = ""
-    sub_vendor_id = ""
-    vendor_id     = "15B3"
-    x_vga         = false
-  }
-  ```
+  @include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
 
-  - `host` (string) - The PCI ID of a host’s PCI device or a PCI virtual function. You can us the `lspci` command to list existing PCI devices. Either this or the `mapping` key must be set.
+##### Optional:
 
-  - `mapping` (string) - The ID of a cluster wide mapping. Either this or the `host` key must be set. 
-
-  - `pcie` (bool) - Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
-
-  - `device_id` (string) - Override PCI device ID visible to guest.
-
-  - `legacy_igd` (bool) - Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
-
-  - `mdev` (string) - The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
-
-  - `rombar` (bool) - Specify whether or not the device’s ROM will be visible in the guest’s memory map. Defaults to `true`.
-
-  - `romfile` (string) - Custom PCI device rom filename (must be located in `/usr/share/kvm/`). 
-
-  - `sub_device_id` (string) - Override PCI subsystem device ID visible to guest.
-
-  - `sub_vendor_id` (string) - Override PCI subsystem vendor ID visible to guest.
-
-  - `vendor_id` (string) - Override PCI vendor ID visible to guest.
-
-  - `x_vga` (bool) - Enable vfio-vga device support. Defaults to `false`.
+  @include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'
 
 - `template_name` (string) - Name of the template. Defaults to the generated
   name used during creation.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -431,10 +431,6 @@ or responding to pattern `/dev/.+`. Example:
 
 @include 'builder/proxmox/common/pciDeviceConfig.mdx'
 
-#### Required:
-
-@include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
-
 #### Optional:
 
 @include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -413,15 +413,15 @@ or responding to pattern `/dev/.+`. Example:
 
 - `machine` - (string) - Set the machine type. Supported values are 'pc' or 'q35'.
 
-#### VirtIO RNG device
+### VirtIO RNG device
 
 @include 'builder/proxmox/common/rng0Config.mdx'
 
-##### Required:
+#### Required:
 
 @include 'builder/proxmox/common/rng0Config-required.mdx'
 
-##### Optional:
+#### Optional:
 
 @include 'builder/proxmox/common/rng0Config-not-required.mdx'
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -29,12 +29,14 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
-In addition to the items listed here, you will want to look at the general
-configuration references for
-[VirtIO RNG device](#virtio-rng-device),
-[PCI Devices](#pci-devices),
-and [Communicator](/packer/docs/templates/legacy_json_templates/communicator)
+You may also want to take look at the general configuration references for
+[VirtIO RNG device](#virtio-rng-device)
+and [PCI Devices](#pci-devices)
 configuration references, which can be found further down the page.
+
+In addition to the options listed here, a
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
+builder.
 
 If no communicator is defined, an SSH key is generated for use, and is used
 in the image's Cloud-Init settings for provisioning.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -248,15 +248,12 @@ or responding to pattern `/dev/.+`. Example:
     rather than a rotational disk.
 
 @include 'builder/proxmox/common/pciDeviceConfig.mdx'
-
 ##### Required:
 
   @include 'builder/proxmox/common/pciDeviceConfig-required.mdx'
-
 ##### Optional:
 
   @include 'builder/proxmox/common/pciDeviceConfig-not-required.mdx'
-
 - `template_name` (string) - Name of the template. Defaults to the generated
   name used during creation.
 


### PR DESCRIPTION
This PR introduces the `pci_devices` block to allow mapping host's PCI devices into the guest VM. This is often used to passthrough a graphics card or a network adapter. Devices that are mapped into a guest VM are no longer available on the host.