### PR TITLE
docs: fix builders description

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,11 +26,11 @@ Packer is able to target both ISO and existing Cloud-Init images.
 
 #### Builders
 
-- [proxmox-clone](/packer/integrations/hashicorp/proxmox/latest/components/builder/clone) - The proxmox Packer
-  builder is able to create new images for use with Proxmox VE. The builder
-  takes an ISO source, runs any provisioning necessary on the image after
+- [proxmox-clone](/packer/integrations/hashicorp/proxmox/latest/components/builder/clone) - The proxmox image
+  builder is able to create new images for use with Proxmox VE. The builder takes a cloud-init enabled virtual machine
+  template name, runs any provisioning necessary on the image after
   launching it, then creates a virtual machine template.
-- [proxmox-iso](/packer/integrations/hashicorp/proxmox/latest/components/builder/iso) - The proxmox Packer
+- [proxmox-iso](/packer/integrations/hashicorp/proxmox/latest/components/builder/iso) - The proxmox ISO
   builder is able to create new images for use with Proxmox VE. The builder
   takes an ISO source, runs any provisioning necessary on the image after
   launching it, then creates a virtual machine template.

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -1,6 +1,6 @@
 ---
 description: |
-  The proxmox Packer builder is able to create new images for use with
+  The proxmox ISO builder is able to create new images for use with
   Proxmox VE. The builder takes an ISO source, runs any provisioning
   necessary on the image after launching it, then creates a virtual machine
   template.


### PR DESCRIPTION
Hello folks ! :) 

This change is a proposed fix of the builders documentation.
The two descriptions in [this section](https://developer.hashicorp.com/packer/integrations/hashicorp/proxmox) were identical.

I also took the liberty of changing the description for the `iso` builder (very slightly) to be more coherent.

Let me know if the changes are OK with you ;)

