### PR TITLE
goreleaser: don't rely on ci-make-docs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,6 @@ before:
     # We strongly recommend running tests to catch any regression before release.
     # Even though, this an optional step.
     - go test ./...
-    # As part of the release doc files are included as a separate deliverable for
-    # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
-    - make ci-release-docs
     # Check plugin compatibility with required version of the Packer SDK
     - make plugin-check
 builds:


### PR DESCRIPTION
Since the ci-make-docs target is no longer part of the Makefile, we cannot rely on it for making the latest docs, and therefore we must remove that from the goreleaser file too.