### PR TITLE
add tags

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -179,6 +179,9 @@ boot time.
   and are limited to the range 100-999999999.
   If not given, the next free ID on the cluster will be used.
 
+- `tags` (string) - The tags to set. This is a semicolon separated list. For example,
+  `debian-12;template`.
+
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
   Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -110,6 +110,9 @@ in the image's Cloud-Init settings for provisioning.
   and are limited to the range 100-999999999.
   If not given, the next free ID on the cluster will be used.
 
+- `tags` (string) - The tags to set. This is a semicolon separated list. For example,
+  `debian-12;template`.
+
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
   Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -88,6 +88,7 @@ type FlatConfig struct {
 	TaskTimeout               *string                            `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
+	Tags                      *string                            `mapstructure:"tags" cty:"tags" hcl:"tags"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -213,6 +214,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"task_timeout":                 &hcldec.AttrSpec{Name: "task_timeout", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
+		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -93,6 +93,10 @@ type Config struct {
 	// If not given, the next free ID on the cluster will be used.
 	VMID int `mapstructure:"vm_id"`
 
+	// The tags to set. This is a semicolon separated list. For example,
+	// `debian-12;template`.
+	Tags string `mapstructure:"tags"`
+
 	// Override default boot order. Format example `order=virtio0;ide2;net0`.
 	// Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 	Boot string `mapstructure:"boot"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -87,6 +87,7 @@ type FlatConfig struct {
 	TaskTimeout               *string                    `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                    `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                       `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
+	Tags                      *string                    `mapstructure:"tags" cty:"tags" hcl:"tags"`
 	Boot                      *string                    `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                       `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                       `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -206,6 +207,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"task_timeout":                 &hcldec.AttrSpec{Name: "task_timeout", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
+		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -113,6 +113,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Name:           c.VMName,
 		Agent:          agent,
 		QemuKVM:        &kvm,
+		Tags:           c.Tags,
 		Boot:           c.Boot, // Boot priority, example: "order=virtio0;ide2;net0", virtio0:Disk0 -> ide0:CDROM -> net0:Network
 		QemuCpu:        c.CPUType,
 		Description:    "Packer ephemeral build VM",

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -88,6 +88,7 @@ type FlatConfig struct {
 	TaskTimeout               *string                            `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
+	Tags                      *string                            `mapstructure:"tags" cty:"tags" hcl:"tags"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -216,6 +217,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"task_timeout":                 &hcldec.AttrSpec{Name: "task_timeout", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
+		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -42,6 +42,9 @@
   and are limited to the range 100-999999999.
   If not given, the next free ID on the cluster will be used.
 
+- `tags` (string) - The tags to set. This is a semicolon separated list. For example,
+  `debian-12;template`.
+
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
   Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 


### PR DESCRIPTION
This adds support for tags.

To set the tags, set the `tags` property value to a semicolon separated string. For example:

```hcl
source "proxmox-iso" "debian-amd64" {
  template_name            = "template-debian-${var.version}"
  template_description     = "See https://github.com/rgl/debian-vagrant"
  tags                     = "debian-${var.version};template" # TODO declare this as an array instead?

```

I'm still unsure whether to support an array instead, i.e., `"debian-${var.version};template"` vs `["debian-${var.version", "template"]`. Please advice.

Closes #193
