### PR TITLE
Strip trailing / from proxmox url

### DIFF
--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -6,6 +6,7 @@ package proxmox
 import (
 	"crypto/tls"
 	"log"
+	"strings"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
@@ -15,7 +16,7 @@ func newProxmoxClient(config Config) (*proxmox.Client, error) {
 		InsecureSkipVerify: config.SkipCertValidation,
 	}
 
-	client, err := proxmox.NewClient(config.proxmoxURL.String(), nil, "", tlsConfig, "", int(config.TaskTimeout.Seconds()))
+	client, err := proxmox.NewClient(strings.TrimSuffix(config.proxmoxURL.String(), "/"), nil, "", tlsConfig, "", int(config.TaskTimeout.Seconds()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Accidentally adding a trailing / to the proxmox_url causes issues with additional_iso_files. A 501 can be seen and the upload fails.
Unfortunately, that error is a red herring. While the url is logged in debug mode, it is simply a log print and not obvious as it doesn't actually point out the error 

Can replicate by simply specifying a / at the end of the proxmox_url config
proxmox_url ="https://my-proxmox.my-domain:8006/api2/json/"

The upload request becomes; eg. POST /api2/json//nodes/pve/storage/local/upload
Note the json// with the extra slash.

Stripping the trailing slash should resolve this issue when someone accidentally copies/pastes the url to the config.


Edit: Another option would be to check the string format in general and give an error to resolve before continuing. 
