### PR TITLE
Fix typo in documentation of network_adapters

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -223,7 +223,7 @@ boot time.
 
 - `vga` (vgaConfig) - The graphics adapter to use. See [VGA Config](#vga-config).
 
-- `network_adapters` ([]NICConfig) - The graphics adapter to use. See [Network Adapters](#network-adapters)
+- `network_adapters` ([]NICConfig) - The network adapter to use. See [Network Adapters](#network-adapters)
 
 - `disks` ([]diskConfig) - Disks attached to the virtual machine. See [Disks](#disks)
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -154,7 +154,7 @@ in the image's Cloud-Init settings for provisioning.
 
 - `vga` (vgaConfig) - The graphics adapter to use. See [VGA Config](#vga-config).
 
-- `network_adapters` ([]NICConfig) - The graphics adapter to use. See [Network Adapters](#network-adapters)
+- `network_adapters` ([]NICConfig) - The network adapter to use. See [Network Adapters](#network-adapters)
 
 - `disks` ([]diskConfig) - Disks attached to the virtual machine. See [Disks](#disks)
 

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -138,7 +138,7 @@ type Config struct {
 	Rng0 rng0Config `mapstructure:"rng0"`
 	// The graphics adapter to use. See [VGA Config](#vga-config).
 	VGA vgaConfig `mapstructure:"vga"`
-	// The graphics adapter to use. See [Network Adapters](#network-adapters)
+	// The network adapter to use. See [Network Adapters](#network-adapters)
 	NICs []NICConfig `mapstructure:"network_adapters"`
 	// Disks attached to the virtual machine. See [Disks](#disks)
 	Disks []diskConfig `mapstructure:"disks"`

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -86,7 +86,7 @@
 
 - `vga` (vgaConfig) - The graphics adapter to use. See [VGA Config](#vga-config).
 
-- `network_adapters` ([]NICConfig) - The graphics adapter to use. See [Network Adapters](#network-adapters)
+- `network_adapters` ([]NICConfig) - The network adapter to use. See [Network Adapters](#network-adapters)
 
 - `disks` ([]diskConfig) - Disks attached to the virtual machine. See [Disks](#disks)
 


### PR DESCRIPTION
This PR fixes a small typo for the description of `network_adapters`, which appears to have been copied without modification from the `vga` option.