### PR TITLE
Add 'args' as optional configuration parameter when creating a VM

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -36,7 +36,6 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
-
 ### Required:
 
 <!-- Code generated from the comments of the Config struct in builder/proxmox/clone/config.go; DO NOT EDIT MANUALLY -->
@@ -49,7 +48,6 @@ in the image's Cloud-Init settings for provisioning.
   Either `clone_vm` or `clone_vm_id` must be specifed.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/clone/config.go; -->
-
 
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -65,7 +63,6 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
-
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
@@ -73,52 +70,52 @@ boot time.
   will be copied onto the CD recursively, preserving directory structure
   hierarchy. Symlinks will have the link's target copied into the directory
   tree on the CD where the symlink was. File globbing is allowed.
-  
+
   Usage example (JSON):
-  
+
   ```json
   "cd_files": ["./somedirectory/meta-data", "./somedirectory/user-data"],
   "cd_label": "cidata",
   ```
-  
+
   Usage example (HCL):
-  
+
   ```hcl
   cd_files = ["./somedirectory/meta-data", "./somedirectory/user-data"]
   cd_label = "cidata"
   ```
-  
+
   The above will create a CD with two files, user-data and meta-data in the
   CD root. This specific example is how you would create a CD that can be
   used for an Ubuntu 20.04 autoinstall.
-  
+
   Since globbing is also supported,
-  
+
   ```hcl
   cd_files = ["./somedirectory/*"]
   cd_label = "cidata"
   ```
-  
+
   Would also be an acceptable way to define the above cd. The difference
   between providing the directory with or without the glob is whether the
   directory itself or its contents will be at the CD root.
-  
+
   Use of this option assumes that you have a command line tool installed
   that can handle the iso creation. Packer will use one of the following
   tools:
-  
-    * xorriso
-    * mkisofs
-    * hdiutil (normally found in macOS)
-    * oscdimg (normally found in Windows as part of the Windows ADK)
+
+  - xorriso
+  - mkisofs
+  - hdiutil (normally found in macOS)
+  - oscdimg (normally found in Windows as part of the Windows ADK)
 
 - `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
   contents. It can be used alongside `cd_files`, which is useful to add large
   files without loading them into memory. If any paths are specified by both,
   the contents in `cd_content` will take precedence.
-  
+
   Usage example (HCL):
-  
+
   ```hcl
   cd_files = ["vendor-data"]
   cd_content = {
@@ -131,7 +128,6 @@ boot time.
 - `cd_label` (string) - CD Label
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
-
 
 ### Optional:
 
@@ -169,7 +165,7 @@ boot time.
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
 - `task_timeout` (duration string | ex: "1h5m2s") - `task_timeout` (duration string | ex: "10m") - The timeout for
-   Promox API operations, e.g. clones. Defaults to 1 minute.
+  Promox API operations, e.g. clones. Defaults to 1 minute.
 
 - `vm_name` (string) - Name of the virtual machine during creation. If not
   given, a random uuid will be used.
@@ -181,6 +177,9 @@ boot time.
 
 - `tags` (string) - The tags to set. This is a semicolon separated list. For example,
   `debian-12;template`.
+
+- `args` (string) - Arbitrary arguments passed to KVM. For example ` -no-reboot -smbios type=0,vendor=FOO`.
+  Note: this option is for experts only.
 
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
   Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
@@ -233,13 +232,10 @@ boot time.
   the virtual machine. It may pass through a host serial device `/dev/ttyS0`
   or create unix socket on the host `socket`. Each element can be `socket`
   or responding to pattern `/dev/.+`. Example:
-  
-    ```json
-    [
-      "socket",
-      "/dev/ttyS1"
-    ]
-    ```
+
+  ```json
+  ["socket", "/dev/ttyS1"]
+  ```
 
 - `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
@@ -274,7 +270,6 @@ boot time.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
-
 <!-- Code generated from the comments of the Config struct in builder/proxmox/clone/config.go; DO NOT EDIT MANUALLY -->
 
 - `full_clone` (boolean) - Whether to run a full or shallow clone from the base clone_vm. Defaults to `true`.
@@ -290,22 +285,20 @@ boot time.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/clone/config.go; -->
 
-
 ### VGA Config
 
 <!-- Code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `vga` (object) - The graphics adapter to use. Example:
 
-	```json
-	{
-	  "type": "vmware",
-	  "memory": 32
-	}
-	```
+  ```json
+  {
+    "type": "vmware",
+    "memory": 32
+  }
+  ```
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -319,7 +312,6 @@ boot time.
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
 
-
 ### Network Adapters
 
 <!-- Code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -330,19 +322,16 @@ Example:
 
 ```json
 [
-
-	{
-	  "model": "virtio",
-	  "bridge": "vmbr0",
-	  "vlan_tag": "10",
-	  "firewall": true
-	}
-
+  {
+    "model": "virtio",
+    "bridge": "vmbr0",
+    "vlan_tag": "10",
+    "firewall": true
+  }
 ]
 ```
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -381,7 +370,6 @@ Example:
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
 
-
 ### Disks
 
 <!-- Code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -392,19 +380,16 @@ Example:
 
 ```json
 [
-
-	{
-	  "type": "scsi",
-	  "disk_size": "5G",
-	  "storage_pool": "local-lvm",
-	  "storage_pool_type": "lvm"
-	}
-
+  {
+    "type": "scsi",
+    "disk_size": "5G",
+    "storage_pool": "local-lvm",
+    "storage_pool_type": "lvm"
+  }
 ]
 ```
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -442,11 +427,10 @@ Example:
 
 - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
   rather than a rotational disk.
-  
+
   This cannot work with virtio disks.
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
-
 
 ### CloudInit Ip Configuration
 
@@ -459,19 +443,16 @@ Usage example (JSON):
 
 ```json
 [
-
-	{
-	  "ip": "192.168.1.55/24",
-	  "gateway": "192.168.1.1",
-	  "ip6": "fda8:a260:6eda:20::4da/128",
-	  "gateway6": "fda8:a260:6eda:20::1"
-	}
-
+  {
+    "ip": "192.168.1.55/24",
+    "gateway": "192.168.1.1",
+    "ip6": "fda8:a260:6eda:20::4da/128",
+    "gateway6": "fda8:a260:6eda:20::1"
+  }
 ]
 ```
 
 <!-- End of code generated from the comments of the cloudInitIpconfig struct in builder/proxmox/clone/config.go; -->
-
 
 <!-- Code generated from the comments of the cloudInitIpconfig struct in builder/proxmox/clone/config.go; DO NOT EDIT MANUALLY -->
 
@@ -485,7 +466,6 @@ Usage example (JSON):
 
 <!-- End of code generated from the comments of the cloudInitIpconfig struct in builder/proxmox/clone/config.go; -->
 
-
 ### Additional ISO Files
 
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -496,19 +476,16 @@ Example:
 
 ```json
 [
-
-	{
-	  "device": "scsi5",
-	  "iso_file": "local:iso/virtio-win-0.1.185.iso",
-	  "unmount": true,
-	  "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
-	}
-
+  {
+    "device": "scsi5",
+    "iso_file": "local:iso/virtio-win-0.1.185.iso",
+    "unmount": true,
+    "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
+  }
 ]
 ```
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
-
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -519,11 +496,11 @@ file mode in order to perform a download.
 
 go-getter supports the following protocols:
 
-* Local files
-* Git
-* Mercurial
-* HTTP
-* Amazon S3
+- Local files
+- Git
+- Mercurial
+- HTTP
+- Amazon S3
 
 Examples:
 go-getter can guess the checksum type based on `iso_checksum` length, and it is
@@ -591,7 +568,6 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
-
 #### Required
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
@@ -603,25 +579,25 @@ In HCL2:
   "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
   "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
   list of valid checksum values:
-   * md5:090992ba9fd140077b0661cb75f7ce13
-   * 090992ba9fd140077b0661cb75f7ce13
-   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
-   * ebfb681885ddf1234c18094a45bbeafd91467911
-   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
-   * file:file://./local/path/file.sum
-   * file:./local/path/file.sum
-   * none
-  Although the checksum will not be verified when it is set to "none",
-  this is not recommended since these files can be very large and
-  corruption does happen from time to time.
+
+  - md5:090992ba9fd140077b0661cb75f7ce13
+  - 090992ba9fd140077b0661cb75f7ce13
+  - sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+  - ebfb681885ddf1234c18094a45bbeafd91467911
+  - sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+  - ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+  - file:http://releases.ubuntu.com/20.04/SHA256SUMS
+  - file:file://./local/path/file.sum
+  - file:./local/path/file.sum
+  - none
+    Although the checksum will not be verified when it is set to "none",
+    this is not recommended since these files can be very large and
+    corruption does happen from time to time.
 
 - `iso_url` (string) - A URL to the ISO containing the installation image or virtual hard drive
   (VHD or VHDX) file to clone.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
-
 
 #### Optional
 
@@ -641,7 +617,6 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
-
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `device` (string) - Bus type and bus index that the ISO will be mounted on. Can be `ideX`,
@@ -659,13 +634,12 @@ In HCL2:
   the ISO file.
 
 - `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
-  
+
   Defaults to `false`
 
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
-
 
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -681,7 +655,6 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
-
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
@@ -689,52 +662,52 @@ boot time.
   will be copied onto the CD recursively, preserving directory structure
   hierarchy. Symlinks will have the link's target copied into the directory
   tree on the CD where the symlink was. File globbing is allowed.
-  
+
   Usage example (JSON):
-  
+
   ```json
   "cd_files": ["./somedirectory/meta-data", "./somedirectory/user-data"],
   "cd_label": "cidata",
   ```
-  
+
   Usage example (HCL):
-  
+
   ```hcl
   cd_files = ["./somedirectory/meta-data", "./somedirectory/user-data"]
   cd_label = "cidata"
   ```
-  
+
   The above will create a CD with two files, user-data and meta-data in the
   CD root. This specific example is how you would create a CD that can be
   used for an Ubuntu 20.04 autoinstall.
-  
+
   Since globbing is also supported,
-  
+
   ```hcl
   cd_files = ["./somedirectory/*"]
   cd_label = "cidata"
   ```
-  
+
   Would also be an acceptable way to define the above cd. The difference
   between providing the directory with or without the glob is whether the
   directory itself or its contents will be at the CD root.
-  
+
   Use of this option assumes that you have a command line tool installed
   that can handle the iso creation. Packer will use one of the following
   tools:
-  
-    * xorriso
-    * mkisofs
-    * hdiutil (normally found in macOS)
-    * oscdimg (normally found in Windows as part of the Windows ADK)
+
+  - xorriso
+  - mkisofs
+  - hdiutil (normally found in macOS)
+  - oscdimg (normally found in Windows as part of the Windows ADK)
 
 - `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
   contents. It can be used alongside `cd_files`, which is useful to add large
   files without loading them into memory. If any paths are specified by both,
   the contents in `cd_content` will take precedence.
-  
+
   Usage example (HCL):
-  
+
   ```hcl
   cd_files = ["vendor-data"]
   cd_content = {
@@ -748,7 +721,6 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
-
 ### EFI Config
 
 <!-- Code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -759,17 +731,14 @@ This needs to be set if you use ovmf uefi boot (supersedes the `efidisk` option)
 Usage example (JSON):
 
 ```json
-
-	{
-	  "efi_storage_pool": "local",
-	  "pre_enrolled_keys": true,
-	  "efi_type": "4m"
-	}
-
+{
+  "efi_storage_pool": "local",
+  "pre_enrolled_keys": true,
+  "efi_type": "4m"
+}
 ```
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -785,15 +754,14 @@ Usage example (JSON):
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
 
-
 ### VirtIO RNG device
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `rng0` (object): Configure Random Number Generator via VirtIO.
-A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
-The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
-[PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
+  A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
+  The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
+  [PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
 
 HCL2 example:
 
@@ -810,19 +778,16 @@ HCL2 example:
 JSON example:
 
 ```json
-
-	{
-	    "rng0": {
-	        "source": "/dev/urandom",
-	        "max_bytes": 1024,
-	        "period": 1000
-	    }
-	}
-
+{
+  "rng0": {
+    "source": "/dev/urandom",
+    "max_bytes": 1024,
+    "period": 1000
+  }
+}
 ```
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
-
 
 #### Required:
 
@@ -840,7 +805,6 @@ JSON example:
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
 
-
 #### Optional:
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -850,7 +814,6 @@ JSON example:
   Recommended value: `1000`.
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
-
 
 ### PCI devices
 
@@ -886,27 +849,24 @@ HCL2 example:
 JSON example:
 
 ```json
-
-	{
-	  "pci_devices": {
-	    "host"          : "0000:0d:00.1",
-	    "pcie"          : false,
-	    "device_id"     : "1003",
-	    "legacy_igd"    : false,
-	    "mdev"          : "some-model",
-	    "hide_rombar"   : false,
-	    "romfile"       : "vbios.bin",
-	    "sub_device_id" : "",
-	    "sub_vendor_id" : "",
-	    "vendor_id"     : "15B3",
-	    "x_vga"         : false
-	  }
-	}
-
+{
+  "pci_devices": {
+    "host": "0000:0d:00.1",
+    "pcie": false,
+    "device_id": "1003",
+    "legacy_igd": false,
+    "mdev": "some-model",
+    "hide_rombar": false,
+    "romfile": "vbios.bin",
+    "sub_device_id": "",
+    "sub_vendor_id": "",
+    "vendor_id": "15B3",
+    "x_vga": false
+  }
+}
 ```
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -937,7 +897,6 @@ JSON example:
 - `x_vga` (bool) - Enable vfio-vga device support. Defaults to `false`.
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
-
 
 ## Example: Cloud-Init enabled Debian
 

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -36,6 +36,7 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
+
 ### Required:
 
 <!-- Code generated from the comments of the Config struct in builder/proxmox/clone/config.go; DO NOT EDIT MANUALLY -->
@@ -48,6 +49,7 @@ in the image's Cloud-Init settings for provisioning.
   Either `clone_vm` or `clone_vm_id` must be specifed.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/clone/config.go; -->
+
 
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -63,6 +65,7 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
+
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
@@ -70,52 +73,52 @@ boot time.
   will be copied onto the CD recursively, preserving directory structure
   hierarchy. Symlinks will have the link's target copied into the directory
   tree on the CD where the symlink was. File globbing is allowed.
-
+  
   Usage example (JSON):
-
+  
   ```json
   "cd_files": ["./somedirectory/meta-data", "./somedirectory/user-data"],
   "cd_label": "cidata",
   ```
-
+  
   Usage example (HCL):
-
+  
   ```hcl
   cd_files = ["./somedirectory/meta-data", "./somedirectory/user-data"]
   cd_label = "cidata"
   ```
-
+  
   The above will create a CD with two files, user-data and meta-data in the
   CD root. This specific example is how you would create a CD that can be
   used for an Ubuntu 20.04 autoinstall.
-
+  
   Since globbing is also supported,
-
+  
   ```hcl
   cd_files = ["./somedirectory/*"]
   cd_label = "cidata"
   ```
-
+  
   Would also be an acceptable way to define the above cd. The difference
   between providing the directory with or without the glob is whether the
   directory itself or its contents will be at the CD root.
-
+  
   Use of this option assumes that you have a command line tool installed
   that can handle the iso creation. Packer will use one of the following
   tools:
-
-  - xorriso
-  - mkisofs
-  - hdiutil (normally found in macOS)
-  - oscdimg (normally found in Windows as part of the Windows ADK)
+  
+    * xorriso
+    * mkisofs
+    * hdiutil (normally found in macOS)
+    * oscdimg (normally found in Windows as part of the Windows ADK)
 
 - `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
   contents. It can be used alongside `cd_files`, which is useful to add large
   files without loading them into memory. If any paths are specified by both,
   the contents in `cd_content` will take precedence.
-
+  
   Usage example (HCL):
-
+  
   ```hcl
   cd_files = ["vendor-data"]
   cd_content = {
@@ -128,6 +131,7 @@ boot time.
 - `cd_label` (string) - CD Label
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
+
 
 ### Optional:
 
@@ -165,7 +169,7 @@ boot time.
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
 - `task_timeout` (duration string | ex: "1h5m2s") - `task_timeout` (duration string | ex: "10m") - The timeout for
-  Promox API operations, e.g. clones. Defaults to 1 minute.
+   Promox API operations, e.g. clones. Defaults to 1 minute.
 
 - `vm_name` (string) - Name of the virtual machine during creation. If not
   given, a random uuid will be used.
@@ -232,10 +236,13 @@ boot time.
   the virtual machine. It may pass through a host serial device `/dev/ttyS0`
   or create unix socket on the host `socket`. Each element can be `socket`
   or responding to pattern `/dev/.+`. Example:
-
-  ```json
-  ["socket", "/dev/ttyS1"]
-  ```
+  
+    ```json
+    [
+      "socket",
+      "/dev/ttyS1"
+    ]
+    ```
 
 - `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
@@ -270,6 +277,7 @@ boot time.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
+
 <!-- Code generated from the comments of the Config struct in builder/proxmox/clone/config.go; DO NOT EDIT MANUALLY -->
 
 - `full_clone` (boolean) - Whether to run a full or shallow clone from the base clone_vm. Defaults to `true`.
@@ -285,20 +293,22 @@ boot time.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/clone/config.go; -->
 
+
 ### VGA Config
 
 <!-- Code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `vga` (object) - The graphics adapter to use. Example:
 
-  ```json
-  {
-    "type": "vmware",
-    "memory": 32
-  }
-  ```
+	```json
+	{
+	  "type": "vmware",
+	  "memory": 32
+	}
+	```
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -312,6 +322,7 @@ boot time.
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
 
+
 ### Network Adapters
 
 <!-- Code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -322,16 +333,19 @@ Example:
 
 ```json
 [
-  {
-    "model": "virtio",
-    "bridge": "vmbr0",
-    "vlan_tag": "10",
-    "firewall": true
-  }
+
+	{
+	  "model": "virtio",
+	  "bridge": "vmbr0",
+	  "vlan_tag": "10",
+	  "firewall": true
+	}
+
 ]
 ```
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -370,6 +384,7 @@ Example:
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
 
+
 ### Disks
 
 <!-- Code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -380,16 +395,19 @@ Example:
 
 ```json
 [
-  {
-    "type": "scsi",
-    "disk_size": "5G",
-    "storage_pool": "local-lvm",
-    "storage_pool_type": "lvm"
-  }
+
+	{
+	  "type": "scsi",
+	  "disk_size": "5G",
+	  "storage_pool": "local-lvm",
+	  "storage_pool_type": "lvm"
+	}
+
 ]
 ```
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -427,10 +445,11 @@ Example:
 
 - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
   rather than a rotational disk.
-
+  
   This cannot work with virtio disks.
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
+
 
 ### CloudInit Ip Configuration
 
@@ -443,16 +462,19 @@ Usage example (JSON):
 
 ```json
 [
-  {
-    "ip": "192.168.1.55/24",
-    "gateway": "192.168.1.1",
-    "ip6": "fda8:a260:6eda:20::4da/128",
-    "gateway6": "fda8:a260:6eda:20::1"
-  }
+
+	{
+	  "ip": "192.168.1.55/24",
+	  "gateway": "192.168.1.1",
+	  "ip6": "fda8:a260:6eda:20::4da/128",
+	  "gateway6": "fda8:a260:6eda:20::1"
+	}
+
 ]
 ```
 
 <!-- End of code generated from the comments of the cloudInitIpconfig struct in builder/proxmox/clone/config.go; -->
+
 
 <!-- Code generated from the comments of the cloudInitIpconfig struct in builder/proxmox/clone/config.go; DO NOT EDIT MANUALLY -->
 
@@ -466,6 +488,7 @@ Usage example (JSON):
 
 <!-- End of code generated from the comments of the cloudInitIpconfig struct in builder/proxmox/clone/config.go; -->
 
+
 ### Additional ISO Files
 
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -476,16 +499,19 @@ Example:
 
 ```json
 [
-  {
-    "device": "scsi5",
-    "iso_file": "local:iso/virtio-win-0.1.185.iso",
-    "unmount": true,
-    "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
-  }
+
+	{
+	  "device": "scsi5",
+	  "iso_file": "local:iso/virtio-win-0.1.185.iso",
+	  "unmount": true,
+	  "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
+	}
+
 ]
 ```
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
+
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -496,11 +522,11 @@ file mode in order to perform a download.
 
 go-getter supports the following protocols:
 
-- Local files
-- Git
-- Mercurial
-- HTTP
-- Amazon S3
+* Local files
+* Git
+* Mercurial
+* HTTP
+* Amazon S3
 
 Examples:
 go-getter can guess the checksum type based on `iso_checksum` length, and it is
@@ -568,6 +594,7 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
+
 #### Required
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
@@ -579,25 +606,25 @@ In HCL2:
   "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
   "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
   list of valid checksum values:
-
-  - md5:090992ba9fd140077b0661cb75f7ce13
-  - 090992ba9fd140077b0661cb75f7ce13
-  - sha1:ebfb681885ddf1234c18094a45bbeafd91467911
-  - ebfb681885ddf1234c18094a45bbeafd91467911
-  - sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - file:http://releases.ubuntu.com/20.04/SHA256SUMS
-  - file:file://./local/path/file.sum
-  - file:./local/path/file.sum
-  - none
-    Although the checksum will not be verified when it is set to "none",
-    this is not recommended since these files can be very large and
-    corruption does happen from time to time.
+   * md5:090992ba9fd140077b0661cb75f7ce13
+   * 090992ba9fd140077b0661cb75f7ce13
+   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+   * ebfb681885ddf1234c18094a45bbeafd91467911
+   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
+   * file:file://./local/path/file.sum
+   * file:./local/path/file.sum
+   * none
+  Although the checksum will not be verified when it is set to "none",
+  this is not recommended since these files can be very large and
+  corruption does happen from time to time.
 
 - `iso_url` (string) - A URL to the ISO containing the installation image or virtual hard drive
   (VHD or VHDX) file to clone.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
+
 
 #### Optional
 
@@ -617,6 +644,7 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
+
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `device` (string) - Bus type and bus index that the ISO will be mounted on. Can be `ideX`,
@@ -634,12 +662,13 @@ In HCL2:
   the ISO file.
 
 - `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
-
+  
   Defaults to `false`
 
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
+
 
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -655,6 +684,7 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
+
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
@@ -662,52 +692,52 @@ boot time.
   will be copied onto the CD recursively, preserving directory structure
   hierarchy. Symlinks will have the link's target copied into the directory
   tree on the CD where the symlink was. File globbing is allowed.
-
+  
   Usage example (JSON):
-
+  
   ```json
   "cd_files": ["./somedirectory/meta-data", "./somedirectory/user-data"],
   "cd_label": "cidata",
   ```
-
+  
   Usage example (HCL):
-
+  
   ```hcl
   cd_files = ["./somedirectory/meta-data", "./somedirectory/user-data"]
   cd_label = "cidata"
   ```
-
+  
   The above will create a CD with two files, user-data and meta-data in the
   CD root. This specific example is how you would create a CD that can be
   used for an Ubuntu 20.04 autoinstall.
-
+  
   Since globbing is also supported,
-
+  
   ```hcl
   cd_files = ["./somedirectory/*"]
   cd_label = "cidata"
   ```
-
+  
   Would also be an acceptable way to define the above cd. The difference
   between providing the directory with or without the glob is whether the
   directory itself or its contents will be at the CD root.
-
+  
   Use of this option assumes that you have a command line tool installed
   that can handle the iso creation. Packer will use one of the following
   tools:
-
-  - xorriso
-  - mkisofs
-  - hdiutil (normally found in macOS)
-  - oscdimg (normally found in Windows as part of the Windows ADK)
+  
+    * xorriso
+    * mkisofs
+    * hdiutil (normally found in macOS)
+    * oscdimg (normally found in Windows as part of the Windows ADK)
 
 - `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
   contents. It can be used alongside `cd_files`, which is useful to add large
   files without loading them into memory. If any paths are specified by both,
   the contents in `cd_content` will take precedence.
-
+  
   Usage example (HCL):
-
+  
   ```hcl
   cd_files = ["vendor-data"]
   cd_content = {
@@ -721,6 +751,7 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
+
 ### EFI Config
 
 <!-- Code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -731,14 +762,17 @@ This needs to be set if you use ovmf uefi boot (supersedes the `efidisk` option)
 Usage example (JSON):
 
 ```json
-{
-  "efi_storage_pool": "local",
-  "pre_enrolled_keys": true,
-  "efi_type": "4m"
-}
+
+	{
+	  "efi_storage_pool": "local",
+	  "pre_enrolled_keys": true,
+	  "efi_type": "4m"
+	}
+
 ```
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -754,14 +788,15 @@ Usage example (JSON):
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
 
+
 ### VirtIO RNG device
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `rng0` (object): Configure Random Number Generator via VirtIO.
-  A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
-  The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
-  [PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
+A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
+The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
+[PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
 
 HCL2 example:
 
@@ -778,16 +813,19 @@ HCL2 example:
 JSON example:
 
 ```json
-{
-  "rng0": {
-    "source": "/dev/urandom",
-    "max_bytes": 1024,
-    "period": 1000
-  }
-}
+
+	{
+	    "rng0": {
+	        "source": "/dev/urandom",
+	        "max_bytes": 1024,
+	        "period": 1000
+	    }
+	}
+
 ```
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
+
 
 #### Required:
 
@@ -805,6 +843,7 @@ JSON example:
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
 
+
 #### Optional:
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -814,6 +853,7 @@ JSON example:
   Recommended value: `1000`.
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
+
 
 ### PCI devices
 
@@ -849,24 +889,27 @@ HCL2 example:
 JSON example:
 
 ```json
-{
-  "pci_devices": {
-    "host": "0000:0d:00.1",
-    "pcie": false,
-    "device_id": "1003",
-    "legacy_igd": false,
-    "mdev": "some-model",
-    "hide_rombar": false,
-    "romfile": "vbios.bin",
-    "sub_device_id": "",
-    "sub_vendor_id": "",
-    "vendor_id": "15B3",
-    "x_vga": false
-  }
-}
+
+	{
+	  "pci_devices": {
+	    "host"          : "0000:0d:00.1",
+	    "pcie"          : false,
+	    "device_id"     : "1003",
+	    "legacy_igd"    : false,
+	    "mdev"          : "some-model",
+	    "hide_rombar"   : false,
+	    "romfile"       : "vbios.bin",
+	    "sub_device_id" : "",
+	    "sub_vendor_id" : "",
+	    "vendor_id"     : "15B3",
+	    "x_vga"         : false
+	  }
+	}
+
 ```
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -897,6 +940,7 @@ JSON example:
 - `x_vga` (bool) - Enable vfio-vga device support. Defaults to `false`.
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
+
 
 ## Example: Cloud-Init enabled Debian
 

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -182,9 +182,6 @@ boot time.
 - `tags` (string) - The tags to set. This is a semicolon separated list. For example,
   `debian-12;template`.
 
-- `args` (string) - Arbitrary arguments passed to KVM. For example `-no-reboot -smbios type=0,vendor=FOO`.
-  Note: this option is for experts only.
-
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
   Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 
@@ -274,6 +271,10 @@ boot time.
 
 - `vm_interface` (string) - Name of the network interface that Packer gets
   the VMs IP from. Defaults to the first non loopback interface.
+
+- `qemu_additional_args` (string) - Arbitrary arguments passed to KVM.
+  For example `-no-reboot -smbios type=0,vendor=FOO`.
+  Note: this option is for experts only.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -182,7 +182,7 @@ boot time.
 - `tags` (string) - The tags to set. This is a semicolon separated list. For example,
   `debian-12;template`.
 
-- `args` (string) - Arbitrary arguments passed to KVM. For example ` -no-reboot -smbios type=0,vendor=FOO`.
+- `args` (string) - Arbitrary arguments passed to KVM. For example `-no-reboot -smbios type=0,vendor=FOO`.
   Note: this option is for experts only.
 
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -274,7 +274,7 @@ boot time.
 
 - `qemu_additional_args` (string) - Arbitrary arguments passed to KVM.
   For example `-no-reboot -smbios type=0,vendor=FOO`.
-  Note: this option is for experts only.
+  	Note: this option is for experts only.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -113,7 +113,7 @@ in the image's Cloud-Init settings for provisioning.
 - `tags` (string) - The tags to set. This is a semicolon separated list. For example,
   `debian-12;template`.
 
-- `args` (string) - Arbitrary arguments passed to KVM. For example ` -no-reboot -smbios type=0,vendor=FOO`.
+- `args` (string) - Arbitrary arguments passed to KVM. For example `-no-reboot -smbios type=0,vendor=FOO`.
   Note: this option is for experts only.
 
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -113,9 +113,6 @@ in the image's Cloud-Init settings for provisioning.
 - `tags` (string) - The tags to set. This is a semicolon separated list. For example,
   `debian-12;template`.
 
-- `args` (string) - Arbitrary arguments passed to KVM. For example `-no-reboot -smbios type=0,vendor=FOO`.
-  Note: this option is for experts only.
-
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
   Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 
@@ -205,6 +202,10 @@ in the image's Cloud-Init settings for provisioning.
 
 - `vm_interface` (string) - Name of the network interface that Packer gets
   the VMs IP from. Defaults to the first non loopback interface.
+
+- `qemu_additional_args` (string) - Arbitrary arguments passed to KVM. 
+  For example `-no-reboot -smbios type=0,vendor=FOO`.
+  Note: this option is for experts only.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -32,7 +32,6 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
-
 ### Required:
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
@@ -44,25 +43,25 @@ in the image's Cloud-Init settings for provisioning.
   "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
   "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
   list of valid checksum values:
-   * md5:090992ba9fd140077b0661cb75f7ce13
-   * 090992ba9fd140077b0661cb75f7ce13
-   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
-   * ebfb681885ddf1234c18094a45bbeafd91467911
-   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
-   * file:file://./local/path/file.sum
-   * file:./local/path/file.sum
-   * none
-  Although the checksum will not be verified when it is set to "none",
-  this is not recommended since these files can be very large and
-  corruption does happen from time to time.
+
+  - md5:090992ba9fd140077b0661cb75f7ce13
+  - 090992ba9fd140077b0661cb75f7ce13
+  - sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+  - ebfb681885ddf1234c18094a45bbeafd91467911
+  - sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+  - ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+  - file:http://releases.ubuntu.com/20.04/SHA256SUMS
+  - file:file://./local/path/file.sum
+  - file:./local/path/file.sum
+  - none
+    Although the checksum will not be verified when it is set to "none",
+    this is not recommended since these files can be very large and
+    corruption does happen from time to time.
 
 - `iso_url` (string) - A URL to the ISO containing the installation image or virtual hard drive
   (VHD or VHDX) file to clone.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
-
 
 ### Optional:
 
@@ -100,7 +99,7 @@ in the image's Cloud-Init settings for provisioning.
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
 - `task_timeout` (duration string | ex: "1h5m2s") - `task_timeout` (duration string | ex: "10m") - The timeout for
-   Promox API operations, e.g. clones. Defaults to 1 minute.
+  Promox API operations, e.g. clones. Defaults to 1 minute.
 
 - `vm_name` (string) - Name of the virtual machine during creation. If not
   given, a random uuid will be used.
@@ -112,6 +111,9 @@ in the image's Cloud-Init settings for provisioning.
 
 - `tags` (string) - The tags to set. This is a semicolon separated list. For example,
   `debian-12;template`.
+
+- `args` (string) - Arbitrary arguments passed to KVM. For example ` -no-reboot -smbios type=0,vendor=FOO`.
+  Note: this option is for experts only.
 
 - `boot` (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
   Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
@@ -164,13 +166,10 @@ in the image's Cloud-Init settings for provisioning.
   the virtual machine. It may pass through a host serial device `/dev/ttyS0`
   or create unix socket on the host `socket`. Each element can be `socket`
   or responding to pattern `/dev/.+`. Example:
-  
-    ```json
-    [
-      "socket",
-      "/dev/ttyS1"
-    ]
-    ```
+
+  ```json
+  ["socket", "/dev/ttyS1"]
+  ```
 
 - `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
@@ -205,7 +204,6 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
-
 <!-- Code generated from the comments of the Config struct in builder/proxmox/iso/config.go; DO NOT EDIT MANUALLY -->
 
 - `iso_file` (string) - Path to the ISO file to boot from, expressed as a
@@ -217,14 +215,13 @@ in the image's Cloud-Init settings for provisioning.
   the ISO file.
 
 - `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
-  
+
   Defaults to `false`
 
 - `unmount_iso` (bool) - If true, remove the mounted ISO from the template
   after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/iso/config.go; -->
-
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -242,7 +239,6 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
-
 ### Additional ISO Files
 
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -253,19 +249,16 @@ Example:
 
 ```json
 [
-
-	{
-	  "device": "scsi5",
-	  "iso_file": "local:iso/virtio-win-0.1.185.iso",
-	  "unmount": true,
-	  "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
-	}
-
+  {
+    "device": "scsi5",
+    "iso_file": "local:iso/virtio-win-0.1.185.iso",
+    "unmount": true,
+    "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
+  }
 ]
 ```
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
-
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -276,11 +269,11 @@ file mode in order to perform a download.
 
 go-getter supports the following protocols:
 
-* Local files
-* Git
-* Mercurial
-* HTTP
-* Amazon S3
+- Local files
+- Git
+- Mercurial
+- HTTP
+- Amazon S3
 
 Examples:
 go-getter can guess the checksum type based on `iso_checksum` length, and it is
@@ -348,7 +341,6 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
-
 #### Required
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
@@ -360,25 +352,25 @@ In HCL2:
   "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
   "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
   list of valid checksum values:
-   * md5:090992ba9fd140077b0661cb75f7ce13
-   * 090992ba9fd140077b0661cb75f7ce13
-   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
-   * ebfb681885ddf1234c18094a45bbeafd91467911
-   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
-   * file:file://./local/path/file.sum
-   * file:./local/path/file.sum
-   * none
-  Although the checksum will not be verified when it is set to "none",
-  this is not recommended since these files can be very large and
-  corruption does happen from time to time.
+
+  - md5:090992ba9fd140077b0661cb75f7ce13
+  - 090992ba9fd140077b0661cb75f7ce13
+  - sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+  - ebfb681885ddf1234c18094a45bbeafd91467911
+  - sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+  - ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+  - file:http://releases.ubuntu.com/20.04/SHA256SUMS
+  - file:file://./local/path/file.sum
+  - file:./local/path/file.sum
+  - none
+    Although the checksum will not be verified when it is set to "none",
+    this is not recommended since these files can be very large and
+    corruption does happen from time to time.
 
 - `iso_url` (string) - A URL to the ISO containing the installation image or virtual hard drive
   (VHD or VHDX) file to clone.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
-
 
 #### Optional
 
@@ -398,7 +390,6 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
-
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `device` (string) - Bus type and bus index that the ISO will be mounted on. Can be `ideX`,
@@ -416,13 +407,12 @@ In HCL2:
   the ISO file.
 
 - `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
-  
+
   Defaults to `false`
 
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
-
 
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -438,7 +428,6 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
-
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
@@ -446,52 +435,52 @@ boot time.
   will be copied onto the CD recursively, preserving directory structure
   hierarchy. Symlinks will have the link's target copied into the directory
   tree on the CD where the symlink was. File globbing is allowed.
-  
+
   Usage example (JSON):
-  
+
   ```json
   "cd_files": ["./somedirectory/meta-data", "./somedirectory/user-data"],
   "cd_label": "cidata",
   ```
-  
+
   Usage example (HCL):
-  
+
   ```hcl
   cd_files = ["./somedirectory/meta-data", "./somedirectory/user-data"]
   cd_label = "cidata"
   ```
-  
+
   The above will create a CD with two files, user-data and meta-data in the
   CD root. This specific example is how you would create a CD that can be
   used for an Ubuntu 20.04 autoinstall.
-  
+
   Since globbing is also supported,
-  
+
   ```hcl
   cd_files = ["./somedirectory/*"]
   cd_label = "cidata"
   ```
-  
+
   Would also be an acceptable way to define the above cd. The difference
   between providing the directory with or without the glob is whether the
   directory itself or its contents will be at the CD root.
-  
+
   Use of this option assumes that you have a command line tool installed
   that can handle the iso creation. Packer will use one of the following
   tools:
-  
-    * xorriso
-    * mkisofs
-    * hdiutil (normally found in macOS)
-    * oscdimg (normally found in Windows as part of the Windows ADK)
+
+  - xorriso
+  - mkisofs
+  - hdiutil (normally found in macOS)
+  - oscdimg (normally found in Windows as part of the Windows ADK)
 
 - `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
   contents. It can be used alongside `cd_files`, which is useful to add large
   files without loading them into memory. If any paths are specified by both,
   the contents in `cd_content` will take precedence.
-  
+
   Usage example (HCL):
-  
+
   ```hcl
   cd_files = ["vendor-data"]
   cd_content = {
@@ -505,22 +494,20 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
-
 ### VGA Config
 
 <!-- Code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `vga` (object) - The graphics adapter to use. Example:
 
-	```json
-	{
-	  "type": "vmware",
-	  "memory": 32
-	}
-	```
+  ```json
+  {
+    "type": "vmware",
+    "memory": 32
+  }
+  ```
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -534,7 +521,6 @@ boot time.
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
 
-
 ### Network Adapters
 
 <!-- Code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -545,19 +531,16 @@ Example:
 
 ```json
 [
-
-	{
-	  "model": "virtio",
-	  "bridge": "vmbr0",
-	  "vlan_tag": "10",
-	  "firewall": true
-	}
-
+  {
+    "model": "virtio",
+    "bridge": "vmbr0",
+    "vlan_tag": "10",
+    "firewall": true
+  }
 ]
 ```
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -596,7 +579,6 @@ Example:
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
 
-
 ### Disks
 
 <!-- Code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -607,19 +589,16 @@ Example:
 
 ```json
 [
-
-	{
-	  "type": "scsi",
-	  "disk_size": "5G",
-	  "storage_pool": "local-lvm",
-	  "storage_pool_type": "lvm"
-	}
-
+  {
+    "type": "scsi",
+    "disk_size": "5G",
+    "storage_pool": "local-lvm",
+    "storage_pool_type": "lvm"
+  }
 ]
 ```
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -657,11 +636,10 @@ Example:
 
 - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
   rather than a rotational disk.
-  
+
   This cannot work with virtio disks.
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
-
 
 ### EFI Config
 
@@ -673,17 +651,14 @@ This needs to be set if you use ovmf uefi boot (supersedes the `efidisk` option)
 Usage example (JSON):
 
 ```json
-
-	{
-	  "efi_storage_pool": "local",
-	  "pre_enrolled_keys": true,
-	  "efi_type": "4m"
-	}
-
+{
+  "efi_storage_pool": "local",
+  "pre_enrolled_keys": true,
+  "efi_type": "4m"
+}
 ```
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -699,15 +674,14 @@ Usage example (JSON):
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
 
-
 ### VirtIO RNG device
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `rng0` (object): Configure Random Number Generator via VirtIO.
-A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
-The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
-[PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
+  A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
+  The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
+  [PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
 
 HCL2 example:
 
@@ -724,19 +698,16 @@ HCL2 example:
 JSON example:
 
 ```json
-
-	{
-	    "rng0": {
-	        "source": "/dev/urandom",
-	        "max_bytes": 1024,
-	        "period": 1000
-	    }
-	}
-
+{
+  "rng0": {
+    "source": "/dev/urandom",
+    "max_bytes": 1024,
+    "period": 1000
+  }
+}
 ```
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
-
 
 #### Required:
 
@@ -754,7 +725,6 @@ JSON example:
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
 
-
 #### Optional:
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -764,7 +734,6 @@ JSON example:
   Recommended value: `1000`.
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
-
 
 ### PCI devices
 
@@ -800,27 +769,24 @@ HCL2 example:
 JSON example:
 
 ```json
-
-	{
-	  "pci_devices": {
-	    "host"          : "0000:0d:00.1",
-	    "pcie"          : false,
-	    "device_id"     : "1003",
-	    "legacy_igd"    : false,
-	    "mdev"          : "some-model",
-	    "hide_rombar"   : false,
-	    "romfile"       : "vbios.bin",
-	    "sub_device_id" : "",
-	    "sub_vendor_id" : "",
-	    "vendor_id"     : "15B3",
-	    "x_vga"         : false
-	  }
-	}
-
+{
+  "pci_devices": {
+    "host": "0000:0d:00.1",
+    "pcie": false,
+    "device_id": "1003",
+    "legacy_igd": false,
+    "mdev": "some-model",
+    "hide_rombar": false,
+    "romfile": "vbios.bin",
+    "sub_device_id": "",
+    "sub_vendor_id": "",
+    "vendor_id": "15B3",
+    "x_vga": false
+  }
+}
 ```
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
-
 
 #### Optional:
 
@@ -852,7 +818,6 @@ JSON example:
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
 
-
 ### Boot Command
 
 <!-- Code generated from the comments of the BootConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
@@ -868,62 +833,62 @@ sequence. It is an array only to improve readability within the template.
 There are a set of special keys available. If these are in your boot
 command, they will be replaced by the proper key:
 
--   `<bs>` - Backspace
+- `<bs>` - Backspace
 
--   `<del>` - Delete
+- `<del>` - Delete
 
--   `<enter> <return>` - Simulates an actual "enter" or "return" keypress.
+- `<enter> <return>` - Simulates an actual "enter" or "return" keypress.
 
--   `<esc>` - Simulates pressing the escape key.
+- `<esc>` - Simulates pressing the escape key.
 
--   `<tab>` - Simulates pressing the tab key.
+- `<tab>` - Simulates pressing the tab key.
 
--   `<f1> - <f12>` - Simulates pressing a function key.
+- `<f1> - <f12>` - Simulates pressing a function key.
 
--   `<up> <down> <left> <right>` - Simulates pressing an arrow key.
+- `<up> <down> <left> <right>` - Simulates pressing an arrow key.
 
--   `<spacebar>` - Simulates pressing the spacebar.
+- `<spacebar>` - Simulates pressing the spacebar.
 
--   `<insert>` - Simulates pressing the insert key.
+- `<insert>` - Simulates pressing the insert key.
 
--   `<home> <end>` - Simulates pressing the home and end keys.
+- `<home> <end>` - Simulates pressing the home and end keys.
 
-  - `<pageUp> <pageDown>` - Simulates pressing the page up and page down
-    keys.
+- `<pageUp> <pageDown>` - Simulates pressing the page up and page down
+  keys.
 
--   `<menu>` - Simulates pressing the Menu key.
+- `<menu>` - Simulates pressing the Menu key.
 
--   `<leftAlt> <rightAlt>` - Simulates pressing the alt key.
+- `<leftAlt> <rightAlt>` - Simulates pressing the alt key.
 
--   `<leftCtrl> <rightCtrl>` - Simulates pressing the ctrl key.
+- `<leftCtrl> <rightCtrl>` - Simulates pressing the ctrl key.
 
--   `<leftShift> <rightShift>` - Simulates pressing the shift key.
+- `<leftShift> <rightShift>` - Simulates pressing the shift key.
 
--   `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
+- `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
 
-  - `<wait> <wait5> <wait10>` - Adds a 1, 5 or 10 second pause before
-    sending any additional keys. This is useful if you have to generally
-    wait for the UI to update before typing more.
+- `<wait> <wait5> <wait10>` - Adds a 1, 5 or 10 second pause before
+  sending any additional keys. This is useful if you have to generally
+  wait for the UI to update before typing more.
 
-  - `<waitXX>` - Add an arbitrary pause before sending any additional keys.
-    The format of `XX` is a sequence of positive decimal numbers, each with
-    optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`.
-    Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. For
-    example `<wait10m>` or `<wait1m20s>`.
+- `<waitXX>` - Add an arbitrary pause before sending any additional keys.
+  The format of `XX` is a sequence of positive decimal numbers, each with
+  optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`.
+  Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. For
+  example `<wait10m>` or `<wait1m20s>`.
 
-  - `<XXXOn> <XXXOff>` - Any printable keyboard character, and of these
-    "special" expressions, with the exception of the `<wait>` types, can
-    also be toggled on or off. For example, to simulate ctrl+c, use
-    `<leftCtrlOn>c<leftCtrlOff>`. Be sure to release them, otherwise they
-    will be held down until the machine reboots. To hold the `c` key down,
-    you would use `<cOn>`. Likewise, `<cOff>` to release.
+- `<XXXOn> <XXXOff>` - Any printable keyboard character, and of these
+  "special" expressions, with the exception of the `<wait>` types, can
+  also be toggled on or off. For example, to simulate ctrl+c, use
+  `<leftCtrlOn>c<leftCtrlOff>`. Be sure to release them, otherwise they
+  will be held down until the machine reboots. To hold the `c` key down,
+  you would use `<cOn>`. Likewise, `<cOff>` to release.
 
-  - `{{ .HTTPIP }} {{ .HTTPPort }}` - The IP and port, respectively of an
-    HTTP server that is started serving the directory specified by the
-    `http_directory` configuration parameter. If `http_directory` isn't
-    specified, these will be blank!
+- `{{ .HTTPIP }} {{ .HTTPPort }}` - The IP and port, respectively of an
+  HTTP server that is started serving the directory specified by the
+  `http_directory` configuration parameter. If `http_directory` isn't
+  specified, these will be blank!
 
--   `{{ .Name }}` - The name of the VM.
+- `{{ .Name }}` - The name of the VM.
 
 Example boot command. This is actually a working boot command used to start an
 CentOS 6.4 installer:
@@ -994,7 +959,6 @@ For more examples of various boot commands, see the sample projects from our
 
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->
 
-
 #### Optional:
 
 <!-- Code generated from the comments of the BootConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
@@ -1020,7 +984,6 @@ For more examples of various boot commands, see the sample projects from our
 
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->
 
-
 ### Http directory configuration
 
 <!-- Code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; DO NOT EDIT MANUALLY -->
@@ -1036,7 +999,6 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 ```
 
 <!-- End of code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; -->
-
 
 #### Optional:
 
@@ -1057,6 +1019,7 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   address and port of the HTTP server will be available as variables in
   `boot_command`. This is covered in more detail below.
   Example:
+
   ```hcl
     http_content = {
       "/a/b"     = file("http/b")
@@ -1077,7 +1040,6 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   it will work with any network interface.
 
 <!-- End of code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; -->
-
 
 - `http_interface` - (string) - Name of the network interface that Packer gets
   `HTTPIP` from. Defaults to the first non loopback interface.
@@ -1168,9 +1130,9 @@ build {
         }
       ],
       "efi_config": {
-          "efi_storage_pool": "local-lvm",
-          "pre_enrolled_keys": true,
-          "efi_type": "4m"
+        "efi_storage_pool": "local-lvm",
+        "pre_enrolled_keys": true,
+        "efi_type": "4m"
       },
       "iso_file": "local:iso/Fedora-Server-dvd-x86_64-29-1.2.iso",
       "http_directory": "config",

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -32,6 +32,7 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
+
 ### Required:
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
@@ -43,25 +44,25 @@ in the image's Cloud-Init settings for provisioning.
   "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
   "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
   list of valid checksum values:
-
-  - md5:090992ba9fd140077b0661cb75f7ce13
-  - 090992ba9fd140077b0661cb75f7ce13
-  - sha1:ebfb681885ddf1234c18094a45bbeafd91467911
-  - ebfb681885ddf1234c18094a45bbeafd91467911
-  - sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - file:http://releases.ubuntu.com/20.04/SHA256SUMS
-  - file:file://./local/path/file.sum
-  - file:./local/path/file.sum
-  - none
-    Although the checksum will not be verified when it is set to "none",
-    this is not recommended since these files can be very large and
-    corruption does happen from time to time.
+   * md5:090992ba9fd140077b0661cb75f7ce13
+   * 090992ba9fd140077b0661cb75f7ce13
+   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+   * ebfb681885ddf1234c18094a45bbeafd91467911
+   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
+   * file:file://./local/path/file.sum
+   * file:./local/path/file.sum
+   * none
+  Although the checksum will not be verified when it is set to "none",
+  this is not recommended since these files can be very large and
+  corruption does happen from time to time.
 
 - `iso_url` (string) - A URL to the ISO containing the installation image or virtual hard drive
   (VHD or VHDX) file to clone.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
+
 
 ### Optional:
 
@@ -99,7 +100,7 @@ in the image's Cloud-Init settings for provisioning.
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
 - `task_timeout` (duration string | ex: "1h5m2s") - `task_timeout` (duration string | ex: "10m") - The timeout for
-  Promox API operations, e.g. clones. Defaults to 1 minute.
+   Promox API operations, e.g. clones. Defaults to 1 minute.
 
 - `vm_name` (string) - Name of the virtual machine during creation. If not
   given, a random uuid will be used.
@@ -166,10 +167,13 @@ in the image's Cloud-Init settings for provisioning.
   the virtual machine. It may pass through a host serial device `/dev/ttyS0`
   or create unix socket on the host `socket`. Each element can be `socket`
   or responding to pattern `/dev/.+`. Example:
-
-  ```json
-  ["socket", "/dev/ttyS1"]
-  ```
+  
+    ```json
+    [
+      "socket",
+      "/dev/ttyS1"
+    ]
+    ```
 
 - `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
@@ -204,6 +208,7 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 
+
 <!-- Code generated from the comments of the Config struct in builder/proxmox/iso/config.go; DO NOT EDIT MANUALLY -->
 
 - `iso_file` (string) - Path to the ISO file to boot from, expressed as a
@@ -215,13 +220,14 @@ in the image's Cloud-Init settings for provisioning.
   the ISO file.
 
 - `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
-
+  
   Defaults to `false`
 
 - `unmount_iso` (bool) - If true, remove the mounted ISO from the template
   after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/iso/config.go; -->
+
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -239,6 +245,7 @@ in the image's Cloud-Init settings for provisioning.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
+
 ### Additional ISO Files
 
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -249,16 +256,19 @@ Example:
 
 ```json
 [
-  {
-    "device": "scsi5",
-    "iso_file": "local:iso/virtio-win-0.1.185.iso",
-    "unmount": true,
-    "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
-  }
+
+	{
+	  "device": "scsi5",
+	  "iso_file": "local:iso/virtio-win-0.1.185.iso",
+	  "unmount": true,
+	  "iso_checksum": "af2b3cc9fa7905dea5e58d31508d75bba717c2b0d5553962658a47aebc9cc386"
+	}
+
 ]
 ```
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
+
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -269,11 +279,11 @@ file mode in order to perform a download.
 
 go-getter supports the following protocols:
 
-- Local files
-- Git
-- Mercurial
-- HTTP
-- Amazon S3
+* Local files
+* Git
+* Mercurial
+* HTTP
+* Amazon S3
 
 Examples:
 go-getter can guess the checksum type based on `iso_checksum` length, and it is
@@ -341,6 +351,7 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
+
 #### Required
 
 <!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
@@ -352,25 +363,25 @@ In HCL2:
   "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
   "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
   list of valid checksum values:
-
-  - md5:090992ba9fd140077b0661cb75f7ce13
-  - 090992ba9fd140077b0661cb75f7ce13
-  - sha1:ebfb681885ddf1234c18094a45bbeafd91467911
-  - ebfb681885ddf1234c18094a45bbeafd91467911
-  - sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - file:http://releases.ubuntu.com/20.04/SHA256SUMS
-  - file:file://./local/path/file.sum
-  - file:./local/path/file.sum
-  - none
-    Although the checksum will not be verified when it is set to "none",
-    this is not recommended since these files can be very large and
-    corruption does happen from time to time.
+   * md5:090992ba9fd140077b0661cb75f7ce13
+   * 090992ba9fd140077b0661cb75f7ce13
+   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+   * ebfb681885ddf1234c18094a45bbeafd91467911
+   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
+   * file:file://./local/path/file.sum
+   * file:./local/path/file.sum
+   * none
+  Although the checksum will not be verified when it is set to "none",
+  this is not recommended since these files can be very large and
+  corruption does happen from time to time.
 
 - `iso_url` (string) - A URL to the ISO containing the installation image or virtual hard drive
   (VHD or VHDX) file to clone.
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
+
 
 #### Optional
 
@@ -390,6 +401,7 @@ In HCL2:
 
 <!-- End of code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; -->
 
+
 <!-- Code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `device` (string) - Bus type and bus index that the ISO will be mounted on. Can be `ideX`,
@@ -407,12 +419,13 @@ In HCL2:
   the ISO file.
 
 - `iso_download_pve` (bool) - Download the ISO directly from the PVE node rather than through Packer.
-
+  
   Defaults to `false`
 
 - `unmount` (bool) - If true, remove the mounted ISO from the template after finishing. Defaults to `false`.
 
 <!-- End of code generated from the comments of the additionalISOsConfig struct in builder/proxmox/common/config.go; -->
+
 
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
@@ -428,6 +441,7 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
+
 <!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
@@ -435,52 +449,52 @@ boot time.
   will be copied onto the CD recursively, preserving directory structure
   hierarchy. Symlinks will have the link's target copied into the directory
   tree on the CD where the symlink was. File globbing is allowed.
-
+  
   Usage example (JSON):
-
+  
   ```json
   "cd_files": ["./somedirectory/meta-data", "./somedirectory/user-data"],
   "cd_label": "cidata",
   ```
-
+  
   Usage example (HCL):
-
+  
   ```hcl
   cd_files = ["./somedirectory/meta-data", "./somedirectory/user-data"]
   cd_label = "cidata"
   ```
-
+  
   The above will create a CD with two files, user-data and meta-data in the
   CD root. This specific example is how you would create a CD that can be
   used for an Ubuntu 20.04 autoinstall.
-
+  
   Since globbing is also supported,
-
+  
   ```hcl
   cd_files = ["./somedirectory/*"]
   cd_label = "cidata"
   ```
-
+  
   Would also be an acceptable way to define the above cd. The difference
   between providing the directory with or without the glob is whether the
   directory itself or its contents will be at the CD root.
-
+  
   Use of this option assumes that you have a command line tool installed
   that can handle the iso creation. Packer will use one of the following
   tools:
-
-  - xorriso
-  - mkisofs
-  - hdiutil (normally found in macOS)
-  - oscdimg (normally found in Windows as part of the Windows ADK)
+  
+    * xorriso
+    * mkisofs
+    * hdiutil (normally found in macOS)
+    * oscdimg (normally found in Windows as part of the Windows ADK)
 
 - `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
   contents. It can be used alongside `cd_files`, which is useful to add large
   files without loading them into memory. If any paths are specified by both,
   the contents in `cd_content` will take precedence.
-
+  
   Usage example (HCL):
-
+  
   ```hcl
   cd_files = ["vendor-data"]
   cd_content = {
@@ -494,20 +508,22 @@ boot time.
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->
 
+
 ### VGA Config
 
 <!-- Code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `vga` (object) - The graphics adapter to use. Example:
 
-  ```json
-  {
-    "type": "vmware",
-    "memory": 32
-  }
-  ```
+	```json
+	{
+	  "type": "vmware",
+	  "memory": 32
+	}
+	```
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -521,6 +537,7 @@ boot time.
 
 <!-- End of code generated from the comments of the vgaConfig struct in builder/proxmox/common/config.go; -->
 
+
 ### Network Adapters
 
 <!-- Code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -531,16 +548,19 @@ Example:
 
 ```json
 [
-  {
-    "model": "virtio",
-    "bridge": "vmbr0",
-    "vlan_tag": "10",
-    "firewall": true
-  }
+
+	{
+	  "model": "virtio",
+	  "bridge": "vmbr0",
+	  "vlan_tag": "10",
+	  "firewall": true
+	}
+
 ]
 ```
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -579,6 +599,7 @@ Example:
 
 <!-- End of code generated from the comments of the NICConfig struct in builder/proxmox/common/config.go; -->
 
+
 ### Disks
 
 <!-- Code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -589,16 +610,19 @@ Example:
 
 ```json
 [
-  {
-    "type": "scsi",
-    "disk_size": "5G",
-    "storage_pool": "local-lvm",
-    "storage_pool_type": "lvm"
-  }
+
+	{
+	  "type": "scsi",
+	  "disk_size": "5G",
+	  "storage_pool": "local-lvm",
+	  "storage_pool_type": "lvm"
+	}
+
 ]
 ```
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -636,10 +660,11 @@ Example:
 
 - `ssd` (bool) - Drive will be presented to the guest as solid-state drive
   rather than a rotational disk.
-
+  
   This cannot work with virtio disks.
 
 <!-- End of code generated from the comments of the diskConfig struct in builder/proxmox/common/config.go; -->
+
 
 ### EFI Config
 
@@ -651,14 +676,17 @@ This needs to be set if you use ovmf uefi boot (supersedes the `efidisk` option)
 Usage example (JSON):
 
 ```json
-{
-  "efi_storage_pool": "local",
-  "pre_enrolled_keys": true,
-  "efi_type": "4m"
-}
+
+	{
+	  "efi_storage_pool": "local",
+	  "pre_enrolled_keys": true,
+	  "efi_type": "4m"
+	}
+
 ```
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -674,14 +702,15 @@ Usage example (JSON):
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
 
+
 ### VirtIO RNG device
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `rng0` (object): Configure Random Number Generator via VirtIO.
-  A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
-  The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
-  [PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
+A virtual hardware-RNG can be used to provide entropy from the host system to a guest VM helping avoid entropy starvation which might cause the guest system slow down.
+The device is sourced from a host device and guest, his use can be limited: `max_bytes` bytes of data will become available on a `period` ms timer.
+[PVE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) recommends to always use a limiter to avoid guests using too many host resources.
 
 HCL2 example:
 
@@ -698,16 +727,19 @@ HCL2 example:
 JSON example:
 
 ```json
-{
-  "rng0": {
-    "source": "/dev/urandom",
-    "max_bytes": 1024,
-    "period": 1000
-  }
-}
+
+	{
+	    "rng0": {
+	        "source": "/dev/urandom",
+	        "max_bytes": 1024,
+	        "period": 1000
+	    }
+	}
+
 ```
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
+
 
 #### Required:
 
@@ -725,6 +757,7 @@ JSON example:
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
 
+
 #### Optional:
 
 <!-- Code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
@@ -734,6 +767,7 @@ JSON example:
   Recommended value: `1000`.
 
 <!-- End of code generated from the comments of the rng0Config struct in builder/proxmox/common/config.go; -->
+
 
 ### PCI devices
 
@@ -769,24 +803,27 @@ HCL2 example:
 JSON example:
 
 ```json
-{
-  "pci_devices": {
-    "host": "0000:0d:00.1",
-    "pcie": false,
-    "device_id": "1003",
-    "legacy_igd": false,
-    "mdev": "some-model",
-    "hide_rombar": false,
-    "romfile": "vbios.bin",
-    "sub_device_id": "",
-    "sub_vendor_id": "",
-    "vendor_id": "15B3",
-    "x_vga": false
-  }
-}
+
+	{
+	  "pci_devices": {
+	    "host"          : "0000:0d:00.1",
+	    "pcie"          : false,
+	    "device_id"     : "1003",
+	    "legacy_igd"    : false,
+	    "mdev"          : "some-model",
+	    "hide_rombar"   : false,
+	    "romfile"       : "vbios.bin",
+	    "sub_device_id" : "",
+	    "sub_vendor_id" : "",
+	    "vendor_id"     : "15B3",
+	    "x_vga"         : false
+	  }
+	}
+
 ```
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
+
 
 #### Optional:
 
@@ -818,6 +855,7 @@ JSON example:
 
 <!-- End of code generated from the comments of the pciDeviceConfig struct in builder/proxmox/common/config.go; -->
 
+
 ### Boot Command
 
 <!-- Code generated from the comments of the BootConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
@@ -833,62 +871,62 @@ sequence. It is an array only to improve readability within the template.
 There are a set of special keys available. If these are in your boot
 command, they will be replaced by the proper key:
 
-- `<bs>` - Backspace
+-   `<bs>` - Backspace
 
-- `<del>` - Delete
+-   `<del>` - Delete
 
-- `<enter> <return>` - Simulates an actual "enter" or "return" keypress.
+-   `<enter> <return>` - Simulates an actual "enter" or "return" keypress.
 
-- `<esc>` - Simulates pressing the escape key.
+-   `<esc>` - Simulates pressing the escape key.
 
-- `<tab>` - Simulates pressing the tab key.
+-   `<tab>` - Simulates pressing the tab key.
 
-- `<f1> - <f12>` - Simulates pressing a function key.
+-   `<f1> - <f12>` - Simulates pressing a function key.
 
-- `<up> <down> <left> <right>` - Simulates pressing an arrow key.
+-   `<up> <down> <left> <right>` - Simulates pressing an arrow key.
 
-- `<spacebar>` - Simulates pressing the spacebar.
+-   `<spacebar>` - Simulates pressing the spacebar.
 
-- `<insert>` - Simulates pressing the insert key.
+-   `<insert>` - Simulates pressing the insert key.
 
-- `<home> <end>` - Simulates pressing the home and end keys.
+-   `<home> <end>` - Simulates pressing the home and end keys.
 
-- `<pageUp> <pageDown>` - Simulates pressing the page up and page down
-  keys.
+  - `<pageUp> <pageDown>` - Simulates pressing the page up and page down
+    keys.
 
-- `<menu>` - Simulates pressing the Menu key.
+-   `<menu>` - Simulates pressing the Menu key.
 
-- `<leftAlt> <rightAlt>` - Simulates pressing the alt key.
+-   `<leftAlt> <rightAlt>` - Simulates pressing the alt key.
 
-- `<leftCtrl> <rightCtrl>` - Simulates pressing the ctrl key.
+-   `<leftCtrl> <rightCtrl>` - Simulates pressing the ctrl key.
 
-- `<leftShift> <rightShift>` - Simulates pressing the shift key.
+-   `<leftShift> <rightShift>` - Simulates pressing the shift key.
 
-- `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
+-   `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
 
-- `<wait> <wait5> <wait10>` - Adds a 1, 5 or 10 second pause before
-  sending any additional keys. This is useful if you have to generally
-  wait for the UI to update before typing more.
+  - `<wait> <wait5> <wait10>` - Adds a 1, 5 or 10 second pause before
+    sending any additional keys. This is useful if you have to generally
+    wait for the UI to update before typing more.
 
-- `<waitXX>` - Add an arbitrary pause before sending any additional keys.
-  The format of `XX` is a sequence of positive decimal numbers, each with
-  optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`.
-  Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. For
-  example `<wait10m>` or `<wait1m20s>`.
+  - `<waitXX>` - Add an arbitrary pause before sending any additional keys.
+    The format of `XX` is a sequence of positive decimal numbers, each with
+    optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`.
+    Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. For
+    example `<wait10m>` or `<wait1m20s>`.
 
-- `<XXXOn> <XXXOff>` - Any printable keyboard character, and of these
-  "special" expressions, with the exception of the `<wait>` types, can
-  also be toggled on or off. For example, to simulate ctrl+c, use
-  `<leftCtrlOn>c<leftCtrlOff>`. Be sure to release them, otherwise they
-  will be held down until the machine reboots. To hold the `c` key down,
-  you would use `<cOn>`. Likewise, `<cOff>` to release.
+  - `<XXXOn> <XXXOff>` - Any printable keyboard character, and of these
+    "special" expressions, with the exception of the `<wait>` types, can
+    also be toggled on or off. For example, to simulate ctrl+c, use
+    `<leftCtrlOn>c<leftCtrlOff>`. Be sure to release them, otherwise they
+    will be held down until the machine reboots. To hold the `c` key down,
+    you would use `<cOn>`. Likewise, `<cOff>` to release.
 
-- `{{ .HTTPIP }} {{ .HTTPPort }}` - The IP and port, respectively of an
-  HTTP server that is started serving the directory specified by the
-  `http_directory` configuration parameter. If `http_directory` isn't
-  specified, these will be blank!
+  - `{{ .HTTPIP }} {{ .HTTPPort }}` - The IP and port, respectively of an
+    HTTP server that is started serving the directory specified by the
+    `http_directory` configuration parameter. If `http_directory` isn't
+    specified, these will be blank!
 
-- `{{ .Name }}` - The name of the VM.
+-   `{{ .Name }}` - The name of the VM.
 
 Example boot command. This is actually a working boot command used to start an
 CentOS 6.4 installer:
@@ -959,6 +997,7 @@ For more examples of various boot commands, see the sample projects from our
 
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->
 
+
 #### Optional:
 
 <!-- Code generated from the comments of the BootConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
@@ -984,6 +1023,7 @@ For more examples of various boot commands, see the sample projects from our
 
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->
 
+
 ### Http directory configuration
 
 <!-- Code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; DO NOT EDIT MANUALLY -->
@@ -999,6 +1039,7 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 ```
 
 <!-- End of code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; -->
+
 
 #### Optional:
 
@@ -1019,7 +1060,6 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   address and port of the HTTP server will be available as variables in
   `boot_command`. This is covered in more detail below.
   Example:
-
   ```hcl
     http_content = {
       "/a/b"     = file("http/b")
@@ -1040,6 +1080,7 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   it will work with any network interface.
 
 <!-- End of code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; -->
+
 
 - `http_interface` - (string) - Name of the network interface that Packer gets
   `HTTPIP` from. Defaults to the first non loopback interface.
@@ -1130,9 +1171,9 @@ build {
         }
       ],
       "efi_config": {
-        "efi_storage_pool": "local-lvm",
-        "pre_enrolled_keys": true,
-        "efi_type": "4m"
+          "efi_storage_pool": "local-lvm",
+          "pre_enrolled_keys": true,
+          "efi_type": "4m"
       },
       "iso_file": "local:iso/Fedora-Server-dvd-x86_64-29-1.2.iso",
       "http_directory": "config",

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -203,9 +203,9 @@ in the image's Cloud-Init settings for provisioning.
 - `vm_interface` (string) - Name of the network interface that Packer gets
   the VMs IP from. Defaults to the first non loopback interface.
 
-- `qemu_additional_args` (string) - Arbitrary arguments passed to KVM. 
+- `qemu_additional_args` (string) - Arbitrary arguments passed to KVM.
   For example `-no-reboot -smbios type=0,vendor=FOO`.
-  Note: this option is for experts only.
+  	Note: this option is for experts only.
 
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
 

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -89,7 +89,6 @@ type FlatConfig struct {
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Tags                      *string                            `mapstructure:"tags" cty:"tags" hcl:"tags"`
-	Args                      *string                            `mapstructure:"args" cty:"args" hcl:"args"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -124,6 +123,7 @@ type FlatConfig struct {
 	Nameserver                *string                            `mapstructure:"nameserver" required:"false" cty:"nameserver" hcl:"nameserver"`
 	Searchdomain              *string                            `mapstructure:"searchdomain" required:"false" cty:"searchdomain" hcl:"searchdomain"`
 	Ipconfigs                 []FlatcloudInitIpconfig            `mapstructure:"ipconfig" required:"false" cty:"ipconfig" hcl:"ipconfig"`
+	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -216,7 +216,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.String, Required: false},
-		"args":                         &hcldec.AttrSpec{Name: "args", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},
@@ -251,6 +250,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"nameserver":                   &hcldec.AttrSpec{Name: "nameserver", Type: cty.String, Required: false},
 		"searchdomain":                 &hcldec.AttrSpec{Name: "searchdomain", Type: cty.String, Required: false},
 		"ipconfig":                     &hcldec.BlockListSpec{TypeName: "ipconfig", Nested: hcldec.ObjectSpec((*FlatcloudInitIpconfig)(nil).HCL2Spec())},
+		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -117,13 +117,13 @@ type FlatConfig struct {
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
 	VMInterface               *string                            `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
+	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
 	CloneVM                   *string                            `mapstructure:"clone_vm" required:"true" cty:"clone_vm" hcl:"clone_vm"`
 	CloneVMID                 *int                               `mapstructure:"clone_vm_id" required:"true" cty:"clone_vm_id" hcl:"clone_vm_id"`
 	FullClone                 *bool                              `mapstructure:"full_clone" required:"false" cty:"full_clone" hcl:"full_clone"`
 	Nameserver                *string                            `mapstructure:"nameserver" required:"false" cty:"nameserver" hcl:"nameserver"`
 	Searchdomain              *string                            `mapstructure:"searchdomain" required:"false" cty:"searchdomain" hcl:"searchdomain"`
 	Ipconfigs                 []FlatcloudInitIpconfig            `mapstructure:"ipconfig" required:"false" cty:"ipconfig" hcl:"ipconfig"`
-	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -244,13 +244,13 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
+		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},
 		"clone_vm":                     &hcldec.AttrSpec{Name: "clone_vm", Type: cty.String, Required: false},
 		"clone_vm_id":                  &hcldec.AttrSpec{Name: "clone_vm_id", Type: cty.Number, Required: false},
 		"full_clone":                   &hcldec.AttrSpec{Name: "full_clone", Type: cty.Bool, Required: false},
 		"nameserver":                   &hcldec.AttrSpec{Name: "nameserver", Type: cty.String, Required: false},
 		"searchdomain":                 &hcldec.AttrSpec{Name: "searchdomain", Type: cty.String, Required: false},
 		"ipconfig":                     &hcldec.BlockListSpec{TypeName: "ipconfig", Nested: hcldec.ObjectSpec((*FlatcloudInitIpconfig)(nil).HCL2Spec())},
-		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -89,6 +89,7 @@ type FlatConfig struct {
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Tags                      *string                            `mapstructure:"tags" cty:"tags" hcl:"tags"`
+	Args                      *string                            `mapstructure:"args" cty:"args" hcl:"args"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -215,6 +216,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.String, Required: false},
+		"args":                         &hcldec.AttrSpec{Name: "args", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -97,6 +97,10 @@ type Config struct {
 	// `debian-12;template`.
 	Tags string `mapstructure:"tags"`
 
+	// Arbitrary arguments passed to KVM. For example
+	// ` -no-reboot -smbios type=0,vendor=FOO`.
+	// 	Note: this option is for experts only.
+	Args string `mapstructure:"args"`
 	// Override default boot order. Format example `order=virtio0;ide2;net0`.
 	// Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 	Boot string `mapstructure:"boot"`

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -98,7 +98,7 @@ type Config struct {
 	Tags string `mapstructure:"tags"`
 
 	// Arbitrary arguments passed to KVM. For example
-	// ` -no-reboot -smbios type=0,vendor=FOO`.
+	// `-no-reboot -smbios type=0,vendor=FOO`.
 	// 	Note: this option is for experts only.
 	Args string `mapstructure:"args"`
 	// Override default boot order. Format example `order=virtio0;ide2;net0`.

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -97,10 +97,6 @@ type Config struct {
 	// `debian-12;template`.
 	Tags string `mapstructure:"tags"`
 
-	// Arbitrary arguments passed to KVM. For example
-	// `-no-reboot -smbios type=0,vendor=FOO`.
-	// 	Note: this option is for experts only.
-	Args string `mapstructure:"args"`
 	// Override default boot order. Format example `order=virtio0;ide2;net0`.
 	// Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
 	Boot string `mapstructure:"boot"`
@@ -194,6 +190,11 @@ type Config struct {
 	// Name of the network interface that Packer gets
 	// the VMs IP from. Defaults to the first non loopback interface.
 	VMInterface string `mapstructure:"vm_interface"`
+
+	// Arbitrary arguments passed to KVM.
+	// For example `-no-reboot -smbios type=0,vendor=FOO`.
+	// 	Note: this option is for experts only.
+	AdditionalArgs string `mapstructure:"qemu_additional_args"`
 
 	Ctx interpolate.Context `mapstructure-to-hcl2:",skip"`
 }

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -88,7 +88,6 @@ type FlatConfig struct {
 	VMName                    *string                    `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                       `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Tags                      *string                    `mapstructure:"tags" cty:"tags" hcl:"tags"`
-	Args                      *string                    `mapstructure:"args" cty:"args" hcl:"args"`
 	Boot                      *string                    `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                       `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                       `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -117,6 +116,7 @@ type FlatConfig struct {
 	CloudInitStoragePool      *string                    `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
 	VMInterface               *string                    `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
+	AdditionalArgs            *string                    `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
 }
 
 // FlatMapstructure returns a new FlatConfig.

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -88,6 +88,7 @@ type FlatConfig struct {
 	VMName                    *string                    `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                       `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Tags                      *string                    `mapstructure:"tags" cty:"tags" hcl:"tags"`
+	Args                      *string                    `mapstructure:"args" cty:"args" hcl:"args"`
 	Boot                      *string                    `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                       `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                       `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -237,6 +237,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*FlatadditionalISOsConfig)(nil).HCL2Spec())},
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
+		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -114,7 +114,6 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Agent:          agent,
 		QemuKVM:        &kvm,
 		Tags:           c.Tags,
-		Args:           c.Args,
 		Boot:           c.Boot, // Boot priority, example: "order=virtio0;ide2;net0", virtio0:Disk0 -> ide0:CDROM -> net0:Network
 		QemuCpu:        c.CPUType,
 		Description:    "Packer ephemeral build VM",
@@ -134,6 +133,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		QemuSerials:    generateProxmoxSerials(c.Serials),
 		Scsihw:         c.SCSIController,
 		Onboot:         &c.Onboot,
+		Args:           c.AdditionalArgs,
 	}
 
 	// 0 disables the ballooning device, which is useful for all VMs

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -114,6 +114,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Agent:          agent,
 		QemuKVM:        &kvm,
 		Tags:           c.Tags,
+		Args:           c.Args,
 		Boot:           c.Boot, // Boot priority, example: "order=virtio0;ide2;net0", virtio0:Disk0 -> ide0:CDROM -> net0:Network
 		QemuCpu:        c.CPUType,
 		Description:    "Packer ephemeral build VM",

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -89,7 +89,6 @@ type FlatConfig struct {
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Tags                      *string                            `mapstructure:"tags" cty:"tags" hcl:"tags"`
-	Args                      *string                            `mapstructure:"args" cty:"args" hcl:"args"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -127,6 +126,7 @@ type FlatConfig struct {
 	ISOStoragePool            *string                            `mapstructure:"iso_storage_pool" cty:"iso_storage_pool" hcl:"iso_storage_pool"`
 	ISODownloadPVE            *bool                              `mapstructure:"iso_download_pve" cty:"iso_download_pve" hcl:"iso_download_pve"`
 	UnmountISO                *bool                              `mapstructure:"unmount_iso" cty:"unmount_iso" hcl:"unmount_iso"`
+	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -219,7 +219,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.String, Required: false},
-		"args":                         &hcldec.AttrSpec{Name: "args", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},
@@ -257,6 +256,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iso_storage_pool":             &hcldec.AttrSpec{Name: "iso_storage_pool", Type: cty.String, Required: false},
 		"iso_download_pve":             &hcldec.AttrSpec{Name: "iso_download_pve", Type: cty.Bool, Required: false},
 		"unmount_iso":                  &hcldec.AttrSpec{Name: "unmount_iso", Type: cty.Bool, Required: false},
+		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -117,6 +117,7 @@ type FlatConfig struct {
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
 	VMInterface               *string                            `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
+	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
 	ISOChecksum               *string                            `mapstructure:"iso_checksum" required:"true" cty:"iso_checksum" hcl:"iso_checksum"`
 	RawSingleISOUrl           *string                            `mapstructure:"iso_url" required:"true" cty:"iso_url" hcl:"iso_url"`
 	ISOUrls                   []string                           `mapstructure:"iso_urls" cty:"iso_urls" hcl:"iso_urls"`
@@ -126,7 +127,6 @@ type FlatConfig struct {
 	ISOStoragePool            *string                            `mapstructure:"iso_storage_pool" cty:"iso_storage_pool" hcl:"iso_storage_pool"`
 	ISODownloadPVE            *bool                              `mapstructure:"iso_download_pve" cty:"iso_download_pve" hcl:"iso_download_pve"`
 	UnmountISO                *bool                              `mapstructure:"unmount_iso" cty:"unmount_iso" hcl:"unmount_iso"`
-	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -247,6 +247,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
+		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},
 		"iso_checksum":                 &hcldec.AttrSpec{Name: "iso_checksum", Type: cty.String, Required: false},
 		"iso_url":                      &hcldec.AttrSpec{Name: "iso_url", Type: cty.String, Required: false},
 		"iso_urls":                     &hcldec.AttrSpec{Name: "iso_urls", Type: cty.List(cty.String), Required: false},
@@ -256,7 +257,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iso_storage_pool":             &hcldec.AttrSpec{Name: "iso_storage_pool", Type: cty.String, Required: false},
 		"iso_download_pve":             &hcldec.AttrSpec{Name: "iso_download_pve", Type: cty.Bool, Required: false},
 		"unmount_iso":                  &hcldec.AttrSpec{Name: "unmount_iso", Type: cty.Bool, Required: false},
-		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -89,6 +89,7 @@ type FlatConfig struct {
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                               `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
 	Tags                      *string                            `mapstructure:"tags" cty:"tags" hcl:"tags"`
+	Args                      *string                            `mapstructure:"args" cty:"args" hcl:"args"`
 	Boot                      *string                            `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                               `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	BalloonMinimum            *int                               `mapstructure:"ballooning_minimum" cty:"ballooning_minimum" hcl:"ballooning_minimum"`
@@ -218,6 +219,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
 		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.String, Required: false},
+		"args":                         &hcldec.AttrSpec{Name: "args", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"ballooning_minimum":           &hcldec.AttrSpec{Name: "ballooning_minimum", Type: cty.Number, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -32,7 +32,7 @@
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
 - `task_timeout` (duration string | ex: "1h5m2s") - `task_timeout` (duration string | ex: "10m") - The timeout for
-   Promox API operations, e.g. clones. Defaults to 1 minute.
+  Promox API operations, e.g. clones. Defaults to 1 minute.
 
 - `vm_name` (string) - Name of the virtual machine during creation. If not
   given, a random uuid will be used.
@@ -96,13 +96,10 @@
   the virtual machine. It may pass through a host serial device `/dev/ttyS0`
   or create unix socket on the host `socket`. Each element can be `socket`
   or responding to pattern `/dev/.+`. Example:
-  
-    ```json
-    [
-      "socket",
-      "/dev/ttyS1"
-    ]
-    ```
+
+  ```json
+  ["socket", "/dev/ttyS1"]
+  ```
 
 - `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -135,4 +135,8 @@
 - `vm_interface` (string) - Name of the network interface that Packer gets
   the VMs IP from. Defaults to the first non loopback interface.
 
+- `qemu_additional_args` (string) - Arbitrary arguments passed to KVM.
+  For example `-no-reboot -smbios type=0,vendor=FOO`.
+  	Note: this option is for experts only.
+
 <!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -32,7 +32,7 @@
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
 - `task_timeout` (duration string | ex: "1h5m2s") - `task_timeout` (duration string | ex: "10m") - The timeout for
-  Promox API operations, e.g. clones. Defaults to 1 minute.
+   Promox API operations, e.g. clones. Defaults to 1 minute.
 
 - `vm_name` (string) - Name of the virtual machine during creation. If not
   given, a random uuid will be used.
@@ -96,10 +96,13 @@
   the virtual machine. It may pass through a host serial device `/dev/ttyS0`
   or create unix socket on the host `socket`. Each element can be `socket`
   or responding to pattern `/dev/.+`. Example:
-
-  ```json
-  ["socket", "/dev/ttyS1"]
-  ```
+  
+    ```json
+    [
+      "socket",
+      "/dev/ttyS1"
+    ]
+    ```
 
 - `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then


### PR DESCRIPTION
To create macOS VMs in Proxmox, the `args` parameter needs to be set to pass some additional values to the underlying KVM. This PR adds support for setting this in the packer source.

This builds on https://github.com/Telmate/proxmox-api-go/pull/117/files, which already makes it possible to pass `Args` in the `ConfigQemu` struct.

Closes #243

