### PR TITLE
Add validation for iso_storage_pool in an additional_iso_files block

### DIFF
--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -713,6 +713,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 			}
 			c.AdditionalISOFiles[idx].ShouldUploadISO = true
 		}
+		if len(c.AdditionalISOFiles[idx].ISOUrls) != 0 && c.AdditionalISOFiles[idx].ISOStoragePool == "" {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("when specifying iso_url in an additional_iso_files block, iso_storage_pool must also be specified"))
+		}
 		if c.AdditionalISOFiles[idx].Device == "" {
 			log.Printf("AdditionalISOFile %d Device not set, using default 'ide3'", idx)
 			c.AdditionalISOFiles[idx].Device = "ide3"

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -713,9 +713,6 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 			}
 			c.AdditionalISOFiles[idx].ShouldUploadISO = true
 		}
-		if len(c.AdditionalISOFiles[idx].ISOUrls) != 0 && c.AdditionalISOFiles[idx].ISOStoragePool == "" {
-			errs = packersdk.MultiErrorAppend(errs, errors.New("when specifying iso_url in an additional_iso_files block, iso_storage_pool must also be specified"))
-		}
 		if c.AdditionalISOFiles[idx].Device == "" {
 			log.Printf("AdditionalISOFile %d Device not set, using default 'ide3'", idx)
 			c.AdditionalISOFiles[idx].Device = "ide3"
@@ -754,6 +751,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 			if c.AdditionalISOFiles[idx].ISOStoragePool == "" {
 				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("iso_storage_pool not set for storage of generated ISO from cd_files or cd_content"))
 			}
+		}
+		if len(c.AdditionalISOFiles[idx].ISOUrls) != 0 && c.AdditionalISOFiles[idx].ISOStoragePool == "" {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("when specifying iso_url in an additional_iso_files block, iso_storage_pool must also be specified"))
 		}
 		// Check only one option is present
 		options := 0


### PR DESCRIPTION
Add validation of iso_storage_pool in an additional_iso_files block where an iso_url is specified for upload.

```
...
  additional_iso_files {
    device           = "ide0"
    iso_url          = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso"
    iso_checksum     = "none"
    unmount          = true
  }
...
```
Packer build runs without iso_storage_pool specified for the above block now output
```
Error: 1 error(s) occurred:

* when specifying iso_url in an additional_iso_files block, iso_storage_pool must also be specified

  on 197.pkr.hcl line 32:
  (source code not available)
```



Resolves issue described in #197 