### PR TITLE
[Issue 74] Create var for Cloud-Init Disk Type

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -266,6 +266,9 @@ boot time.
 - `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
+- `cloud_init_disk_type` (string) - The type of Cloud-Init disk.
+  Can be `scsi`, `sata`, or `ide`. If not given, defaults to `ide`.
+
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).
 

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -267,7 +267,7 @@ boot time.
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
 - `cloud_init_disk_type` (string) - The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
-  If not given, defaults to `ide`.
+  Defaults to `ide`.
 
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -266,8 +266,8 @@ boot time.
 - `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
-- `cloud_init_disk_type` (string) - The type of Cloud-Init disk.
-  Can be `scsi`, `sata`, or `ide`. If not given, defaults to `ide`.
+- `cloud_init_disk_type` (string) - The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
+  If not given, defaults to `ide`.
 
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -198,7 +198,7 @@ in the image's Cloud-Init settings for provisioning.
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
 - `cloud_init_disk_type` (string) - The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
-  If not given, defaults to `ide`.
+  Defaults to `ide`.
 
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -197,6 +197,9 @@ in the image's Cloud-Init settings for provisioning.
 - `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
+- `cloud_init_disk_type` (string) - The type of Cloud-Init disk.
+  Can be `scsi`, `sata`, or `ide`. If not given, defaults to `ide`.
+
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -197,8 +197,8 @@ in the image's Cloud-Init settings for provisioning.
 - `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
-- `cloud_init_disk_type` (string) - The type of Cloud-Init disk.
-  Can be `scsi`, `sata`, or `ide`. If not given, defaults to `ide`.
+- `cloud_init_disk_type` (string) - The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
+  If not given, defaults to `ide`.
 
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -115,6 +115,7 @@ type FlatConfig struct {
 	TemplateDescription       *string                            `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
 	CloudInit                 *bool                              `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
+	CloudInitDiskType         *string                            `mapstructure:"cloud_init_disk_type" cty:"cloud_init_disk_type" hcl:"cloud_init_disk_type"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
 	VMInterface               *string                            `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
 	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
@@ -242,6 +243,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
+		"cloud_init_disk_type":         &hcldec.AttrSpec{Name: "cloud_init_disk_type", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
 		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -654,12 +654,12 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	}
 	if c.CloudInit {
 		switch c.CloudInitDiskType {
-			case "ide", "scsi", "sata":
-			case "":
-				log.Printf("Cloud-Init disk type not set, using default 'ide'")
-				c.CloudInitDiskType = "ide"
-			default:
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("invalid value for `cloud_init_disk_type` %q: only one of 'ide', 'scsi', 'sata' is valid", c.CloudInitDiskType))
+		case "ide", "scsi", "sata":
+		case "":
+			log.Printf("Cloud-Init disk type not set, using default 'ide'")
+			c.CloudInitDiskType = "ide"
+		default:
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("invalid value for `cloud_init_disk_type` %q: only one of 'ide', 'scsi', 'sata' is valid", c.CloudInitDiskType))
 		}
 	}
 

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -652,14 +652,14 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		log.Printf("SCSI controller not set, using default 'lsi'")
 		c.SCSIController = "lsi"
 	}
-	if c.CloudInit == true {
-		if c.CloudInitDiskType == "" {
-			log.Printf("Cloud-Init disk type not set, using default 'ide'")
-			c.CloudInitDiskType = "ide"
-		} else {
-			if !(c.CloudInitDiskType == "scsi" || c.CloudInitDiskType == "sata" || c.CloudInitDiskType == "ide") {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("supported Cloud-Init disk types are 'ide', 'scsi', and 'sata'"))
-			}
+	if c.CloudInit {
+		switch c.CloudInitDiskType {
+			case "ide", "scsi", "sata":
+			case "":
+				log.Printf("Cloud-Init disk type not set, using default 'ide'")
+				c.CloudInitDiskType = "ide"
+			default:
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("invalid value for `cloud_init_disk_type` %q: only one of 'ide', 'scsi', 'sata' is valid", c.CloudInitDiskType))
 		}
 	}
 

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -184,7 +184,7 @@ type Config struct {
 	// to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 	CloudInitStoragePool string `mapstructure:"cloud_init_storage_pool"`
 	// The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
-	// If not given, defaults to `ide`.
+	// Defaults to `ide`.
 	CloudInitDiskType string `mapstructure:"cloud_init_disk_type"`
 
 	// Additional ISO files attached to the virtual machine.
@@ -651,6 +651,16 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	if c.SCSIController == "" {
 		log.Printf("SCSI controller not set, using default 'lsi'")
 		c.SCSIController = "lsi"
+	}
+	if c.CloudInit == true {
+		if c.CloudInitDiskType == "" {
+			log.Printf("Cloud-Init disk type not set, using default 'ide'")
+			c.CloudInitDiskType = "ide"
+		} else {
+			if !(c.CloudInitDiskType == "scsi" || c.CloudInitDiskType == "sata" || c.CloudInitDiskType == "ide") {
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("supported Cloud-Init disk types are 'ide', 'scsi', and 'sata'"))
+			}
+		}
 	}
 
 	errs = packersdk.MultiErrorAppend(errs, c.Comm.Prepare(&c.Ctx)...)

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -183,6 +183,9 @@ type Config struct {
 	// Name of the Proxmox storage pool
 	// to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 	CloudInitStoragePool string `mapstructure:"cloud_init_storage_pool"`
+	// The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
+	// If not given, defaults to `ide`.
+	CloudInitDiskType string `mapstructure:"cloud_init_disk_type"`
 
 	// Additional ISO files attached to the virtual machine.
 	// See [Additional ISO Files](#additional-iso-files).

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -114,6 +114,7 @@ type FlatConfig struct {
 	TemplateDescription       *string                    `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
 	CloudInit                 *bool                      `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                    `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
+	CloudInitDiskType         *string                    `mapstructure:"cloud_init_disk_type" cty:"cloud_init_disk_type" hcl:"cloud_init_disk_type"`
 	AdditionalISOFiles        []FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
 	VMInterface               *string                    `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
 	AdditionalArgs            *string                    `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
@@ -235,6 +236,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
+		"cloud_init_disk_type":         &hcldec.AttrSpec{Name: "cloud_init_disk_type", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*FlatadditionalISOsConfig)(nil).HCL2Spec())},
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
 		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},

--- a/builder/proxmox/common/step_finalize_template_config.go
+++ b/builder/proxmox/common/step_finalize_template_config.go
@@ -74,9 +74,12 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 					scsiController := fmt.Sprintf("scsi%d", i)
 					diskControllers = append(diskControllers, scsiController)
 				}
-			default:
-				// Unspecified disk type defaults to "ide"
+			// Unspecified disk type defaults to "ide"
+			case "ide":
 				diskControllers = []string{"ide0", "ide1", "ide2", "ide3"}
+			default:
+				state.Put("error", fmt.Errorf("unsupported disk type %q", c.CloudInitDiskType))
+				return multistep.ActionHalt
 			}
 			cloudInitAttached := false
 			// find a free disk controller

--- a/builder/proxmox/common/step_finalize_template_config.go
+++ b/builder/proxmox/common/step_finalize_template_config.go
@@ -80,7 +80,7 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 			}
 			cloudInitAttached := false
 			// find a free disk controller
-			for _, controller := range ideControllers {
+			for _, controller := range diskControllers {
 				if vmParams[controller] == nil {
 					ui.Say("Adding a cloud-init cdrom in storage pool " + cloudInitStoragePool)
 					changes[controller] = cloudInitStoragePool + ":cloudinit"

--- a/builder/proxmox/common/step_finalize_template_config_test.go
+++ b/builder/proxmox/common/step_finalize_template_config_test.go
@@ -109,6 +109,7 @@ func TestTemplateFinalize(t *testing.T) {
 				TemplateName:        "my-template",
 				TemplateDescription: "some-description",
 				CloudInit:           true,
+				CloudInitDiskType:   "ide",
 			},
 			initialVMConfig: map[string]interface{}{
 				"name":        "dummy",
@@ -130,6 +131,7 @@ func TestTemplateFinalize(t *testing.T) {
 				TemplateName:        "my-template",
 				TemplateDescription: "some-description",
 				CloudInit:           true,
+				CloudInitDiskType:   "ide",
 			},
 			initialVMConfig: map[string]interface{}{
 				"name":        "dummy",
@@ -150,6 +152,7 @@ func TestTemplateFinalize(t *testing.T) {
 				TemplateName:        "my-template",
 				TemplateDescription: "some-description",
 				CloudInit:           true,
+				CloudInitDiskType:   "ide",
 			},
 			getConfigErr:        fmt.Errorf("some error"),
 			expectCallSetConfig: false,

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -115,6 +115,7 @@ type FlatConfig struct {
 	TemplateDescription       *string                            `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
 	CloudInit                 *bool                              `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                            `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
+	CloudInitDiskType         *string                            `mapstructure:"cloud_init_disk_type" cty:"cloud_init_disk_type" hcl:"cloud_init_disk_type"`
 	AdditionalISOFiles        []proxmox.FlatadditionalISOsConfig `mapstructure:"additional_iso_files" cty:"additional_iso_files" hcl:"additional_iso_files"`
 	VMInterface               *string                            `mapstructure:"vm_interface" cty:"vm_interface" hcl:"vm_interface"`
 	AdditionalArgs            *string                            `mapstructure:"qemu_additional_args" cty:"qemu_additional_args" hcl:"qemu_additional_args"`
@@ -245,6 +246,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
+		"cloud_init_disk_type":         &hcldec.AttrSpec{Name: "cloud_init_disk_type", Type: cty.String, Required: false},
 		"additional_iso_files":         &hcldec.BlockListSpec{TypeName: "additional_iso_files", Nested: hcldec.ObjectSpec((*proxmox.FlatadditionalISOsConfig)(nil).HCL2Spec())},
 		"vm_interface":                 &hcldec.AttrSpec{Name: "vm_interface", Type: cty.String, Required: false},
 		"qemu_additional_args":         &hcldec.AttrSpec{Name: "qemu_additional_args", Type: cty.String, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -130,7 +130,7 @@
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
 - `cloud_init_disk_type` (string) - The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
-  If not given, defaults to `ide`.
+  Defaults to `ide`.
 
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -129,8 +129,8 @@
 - `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
-- `cloud_init_disk_type` (string) - The type of Cloud-Init disk.
-  Can be `scsi`, `sata`, or `ide`. If not given, defaults to `ide`.
+- `cloud_init_disk_type` (string) - The type of Cloud-Init disk. Can be `scsi`, `sata`, or `ide`
+  If not given, defaults to `ide`.
 
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -129,6 +129,9 @@
 - `cloud_init_storage_pool` (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.
 
+- `cloud_init_disk_type` (string) - The type of Cloud-Init disk.
+  Can be `scsi`, `sata`, or `ide`. If not given, defaults to `ide`.
+
 - `additional_iso_files` ([]additionalISOsConfig) - Additional ISO files attached to the virtual machine.
   See [Additional ISO Files](#additional-iso-files).
 


### PR DESCRIPTION
This change will allow users to specify a `cloud_init_disk_type`, which determines which type (ide, sata, scsi) of drive is created for Cloud-Init. If no value is given or the variable is not provided, the Cloud-Init drive will be created on the first available ide drive, which was how it operated before.
This change should not break any existing configurations that use Cloud-Init, and only provides additional customization to specify a different drive type than the default `ide`

These changes passed the `make test`, as well as packer validation after installing the newly packaged plugin and declaring the `cloud_init_disk_type` var in my hcl file.
I have tested this change with the proxmox-iso builder on each disk type (ide, sata, scsi) as well as not providing the var to ensure it will not break existing configurations. Each option resulted in the expected outcome, where the Cloud-Init drive was created with the type specified by the var.

Closes #74 - By giving the option of SCSI for Cloud-Init