### PR TITLE
Add efi_format options to efi_config

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -772,6 +772,7 @@ Usage example (JSON):
 	{
 	  "efi_storage_pool": "local",
 	  "pre_enrolled_keys": true,
+	  "efi_format": "raw",
 	  "efi_type": "4m"
 	}
 
@@ -785,6 +786,10 @@ Usage example (JSON):
 <!-- Code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `efi_storage_pool` (string) - Name of the Proxmox storage pool to store the EFI disk on.
+
+- `efi_format` (string) - The format of the file backing the disk. Can be
+  `raw`, `cow`, `qcow`, `qed`, `qcow2`, `vmdk` or `cloop`. Defaults to
+  `raw`.
 
 - `pre_enrolled_keys` (bool) - Whether Microsoft Standard Secure Boot keys should be pre-loaded on
   the EFI disk. Defaults to `false`.

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -686,6 +686,7 @@ Usage example (JSON):
 	{
 	  "efi_storage_pool": "local",
 	  "pre_enrolled_keys": true,
+	  "efi_format": "raw",
 	  "efi_type": "4m"
 	}
 
@@ -699,6 +700,10 @@ Usage example (JSON):
 <!-- Code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
 - `efi_storage_pool` (string) - Name of the Proxmox storage pool to store the EFI disk on.
+
+- `efi_format` (string) - The format of the file backing the disk. Can be
+  `raw`, `cow`, `qcow`, `qed`, `qcow2`, `vmdk` or `cloop`. Defaults to
+  `raw`.
 
 - `pre_enrolled_keys` (bool) - Whether Microsoft Standard Secure Boot keys should be pre-loaded on
   the EFI disk. Defaults to `false`.

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -361,6 +361,7 @@ type diskConfig struct {
 //	{
 //	  "efi_storage_pool": "local",
 //	  "pre_enrolled_keys": true,
+//	  "efi_format": "raw",
 //	  "efi_type": "4m"
 //	}
 //
@@ -368,6 +369,10 @@ type diskConfig struct {
 type efiConfig struct {
 	// Name of the Proxmox storage pool to store the EFI disk on.
 	EFIStoragePool string `mapstructure:"efi_storage_pool"`
+	// The format of the file backing the disk. Can be
+	// `raw`, `cow`, `qcow`, `qed`, `qcow2`, `vmdk` or `cloop`. Defaults to
+	// `raw`.
+	EFIFormat string `mapstructure:"efi_format"`
 	// Whether Microsoft Standard Secure Boot keys should be pre-loaded on
 	// the EFI disk. Defaults to `false`.
 	PreEnrolledKeys bool `mapstructure:"pre_enrolled_keys"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -371,6 +371,7 @@ func (*FlatdiskConfig) HCL2Spec() map[string]hcldec.Spec {
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatefiConfig struct {
 	EFIStoragePool  *string `mapstructure:"efi_storage_pool" cty:"efi_storage_pool" hcl:"efi_storage_pool"`
+	EFIFormat       *string `mapstructure:"efi_format" cty:"efi_format" hcl:"efi_format"`
 	PreEnrolledKeys *bool   `mapstructure:"pre_enrolled_keys" cty:"pre_enrolled_keys" hcl:"pre_enrolled_keys"`
 	EFIType         *string `mapstructure:"efi_type" cty:"efi_type" hcl:"efi_type"`
 }
@@ -388,6 +389,7 @@ func (*efiConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spe
 func (*FlatefiConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"efi_storage_pool":  &hcldec.AttrSpec{Name: "efi_storage_pool", Type: cty.String, Required: false},
+		"efi_format":        &hcldec.AttrSpec{Name: "efi_format", Type: cty.String, Required: false},
 		"pre_enrolled_keys": &hcldec.AttrSpec{Name: "pre_enrolled_keys", Type: cty.Bool, Required: false},
 		"efi_type":          &hcldec.AttrSpec{Name: "efi_type", Type: cty.String, Required: false},
 	}

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -460,6 +460,7 @@ func generateProxmoxEfi(efi efiConfig) proxmox.QemuDevice {
 	dev := make(proxmox.QemuDevice)
 	setDeviceParamIfDefined(dev, "storage", efi.EFIStoragePool)
 	setDeviceParamIfDefined(dev, "efitype", efi.EFIType)
+	setDeviceParamIfDefined(dev, "format", efi.EFIFormat)
 	// efi.PreEnrolledKeys can be false, but we only want to set pre-enrolled-keys=0
 	// when other EFI options are set.
 	if len(dev) > 0 {

--- a/docs-partials/builder/proxmox/common/efiConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/efiConfig-not-required.mdx
@@ -2,6 +2,10 @@
 
 - `efi_storage_pool` (string) - Name of the Proxmox storage pool to store the EFI disk on.
 
+- `efi_format` (string) - The format of the file backing the disk. Can be
+  `raw`, `cow`, `qcow`, `qed`, `qcow2`, `vmdk` or `cloop`. Defaults to
+  `raw`.
+
 - `pre_enrolled_keys` (bool) - Whether Microsoft Standard Secure Boot keys should be pre-loaded on
   the EFI disk. Defaults to `false`.
 

--- a/docs-partials/builder/proxmox/common/efiConfig.mdx
+++ b/docs-partials/builder/proxmox/common/efiConfig.mdx
@@ -10,6 +10,7 @@ Usage example (JSON):
 	{
 	  "efi_storage_pool": "local",
 	  "pre_enrolled_keys": true,
+	  "efi_format": "raw",
 	  "efi_type": "4m"
 	}
 


### PR DESCRIPTION
Using this option is possible to create qcow2 EFI disks, instead of the default raw backend.

In previous version of the plugin (with packer 1.9 IIRC), there was a "global" option `format = "qcow2"`  which applied also to EFi disks. When the configuration was changed to `disks` and `efi` sections, we lost the ability to set disk to qcow format.

Having EFI disk in qcow2 format is important, because the raw disks prevent snapshot to be taken.

I've searched the tests suite for EFI configuration to attach my changes, but I found none. I'm sorry, but I'm not quite sure how to write a new test, so I had to leave that to you. Of course, I tested the plug-in on our infrastructure (Proxmox 7.4 + Packer 1.11)