### PR TITLE
fix for remove the old cloud-init on local disks

### DIFF
--- a/builder/proxmox/common/step_remove_cloud_init_drive.go
+++ b/builder/proxmox/common/step_remove_cloud_init_drive.go
@@ -53,7 +53,7 @@ func (s *stepRemoveCloudInitDrive) Run(ctx context.Context, state multistep.Stat
 	}
 
 	for _, controller := range diskControllers {
-		if vmParams[controller] != nil && strings.Contains(vmParams[controller].(string), "-cloudinit,media=cdrom") {
+		if vmParams[controller] != nil && strings.Contains(vmParams[controller].(string), "-cloudinit") && strings.Contains(vmParams[controller].(string), ",media=cdrom") {
 			delete = append(delete, controller)
 		}
 	}


### PR DESCRIPTION
When creating an os+db image, Packer throws an error: Error updating template: ide1 - cloud-init drive is already attached at 'ide0'.

The reason is that Packer did not remove the old cloud-init and trying to insert a new one.

If you create cloud-init on local disks, the file name will also include the disk format:

 my $scfg = PVE::Storage::storage_config($storecfg, $storeid);
        my $name = "vm-$vmid-cloudinit";

        my $fmt = undef;
        if ($scfg->{path}) {
            $fmt = $disk->{format} // "qcow2";
            $name .= ".$fmt";
        } else {
            $fmt = $disk->{format} // "raw";
        }

Closes #273 

