### PR TITLE
[Issue 71] add skip_convert_to_template option

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -262,6 +262,9 @@ boot time.
 - `template_description` (string) - Description of the template, visible in
   the Proxmox interface.
 
+- `skip_convert_to_template` (bool) - Skip converting the VM to a template on completion of build.
+  Defaults to `false`
+
 - `cloud_init` (bool) - If true, add an empty Cloud-Init CDROM drive after the virtual
   machine has been converted to a template. Defaults to `false`.
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -197,6 +197,9 @@ in the image's Cloud-Init settings for provisioning.
 - `template_description` (string) - Description of the template, visible in
   the Proxmox interface.
 
+- `skip_convert_to_template` (bool) - Skip converting the VM to a template on completion of build.
+  Defaults to `false`
+
 - `cloud_init` (bool) - If true, add an empty Cloud-Init CDROM drive after the virtual
   machine has been converted to a template. Defaults to `false`.
 

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -114,6 +114,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                         `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                       `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                       `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
+	SkipConvertToTemplate     *bool                         `mapstructure:"skip_convert_to_template" cty:"skip_convert_to_template" hcl:"skip_convert_to_template"`
 	CloudInit                 *bool                         `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                       `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	CloudInitDiskType         *string                       `mapstructure:"cloud_init_disk_type" cty:"cloud_init_disk_type" hcl:"cloud_init_disk_type"`
@@ -243,6 +244,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
+		"skip_convert_to_template":     &hcldec.AttrSpec{Name: "skip_convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"cloud_init_disk_type":         &hcldec.AttrSpec{Name: "cloud_init_disk_type", Type: cty.String, Required: false},

--- a/builder/proxmox/common/artifact.go
+++ b/builder/proxmox/common/artifact.go
@@ -14,7 +14,8 @@ import (
 
 type Artifact struct {
 	builderID     string
-	templateID    int
+	artifactID    int
+	artifactType  string
 	proxmoxClient *proxmox.Client
 
 	// StateData should store data such as GeneratedData
@@ -34,11 +35,11 @@ func (*Artifact) Files() []string {
 }
 
 func (a *Artifact) Id() string {
-	return strconv.Itoa(a.templateID)
+	return strconv.Itoa(a.artifactID)
 }
 
 func (a *Artifact) String() string {
-	return fmt.Sprintf("A template was created: %d", a.templateID)
+	return fmt.Sprintf("A %s was created: %d", a.artifactType, a.artifactID)
 }
 
 func (a *Artifact) State(name string) interface{} {
@@ -46,7 +47,7 @@ func (a *Artifact) State(name string) interface{} {
 }
 
 func (a *Artifact) Destroy() error {
-	log.Printf("Destroying template: %d", a.templateID)
-	_, err := a.proxmoxClient.DeleteVm(proxmox.NewVmRef(a.templateID))
+	log.Printf("Destroying %s: %d", a.artifactType, a.artifactID)
+	_, err := a.proxmoxClient.DeleteVm(proxmox.NewVmRef(a.artifactID))
 	return err
 }

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -71,7 +71,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook,
 		},
 		&stepRemoveCloudInitDrive{},
 		&stepConvertToTemplate{},
-		&stepFinalizeTemplateConfig{},
+		&stepFinalizeConfig{},
 		&stepSuccess{},
 	}
 	preSteps := b.preSteps
@@ -118,19 +118,24 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook,
 		return nil, errors.New("build was cancelled")
 	}
 
-	// Verify that the template_id was set properly, otherwise we didn't progress through the last step
-	tplID, ok := state.Get("template_id").(int)
+	// Verify that the artifact_id and artifact_type was set properly, otherwise we didn't progress through the last step
+	artifactID, ok := state.Get("artifact_id").(int)
 	if !ok {
-		return nil, fmt.Errorf("template ID could not be determined")
+		return nil, fmt.Errorf("artifact ID could not be determined")
+	}
+
+	artifactType, ok := state.Get("artifact_type").(string)
+	if !ok {
+		return nil, fmt.Errorf("artifact type could not be determined")
 	}
 
 	artifact := &Artifact{
 		builderID:     b.id,
-		templateID:    tplID,
+		artifactID:    artifactID,
+		artifactType:  artifactType,
 		proxmoxClient: b.proxmoxClient,
 		StateData:     map[string]interface{}{"generated_data": state.Get("generated_data")},
 	}
-
 	return artifact, nil
 }
 

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -178,6 +178,9 @@ type Config struct {
 	// Description of the template, visible in
 	// the Proxmox interface.
 	TemplateDescription string `mapstructure:"template_description"`
+	// Skip converting the VM to a template on completion of build.
+	// Defaults to `false`
+	SkipConvertToTemplate bool `mapstructure:"skip_convert_to_template"`
 
 	// If true, add an empty Cloud-Init CDROM drive after the virtual
 	// machine has been converted to a template. Defaults to `false`.

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -113,6 +113,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                 `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string               `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string               `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
+	SkipConvertToTemplate     *bool                 `mapstructure:"skip_convert_to_template" cty:"skip_convert_to_template" hcl:"skip_convert_to_template"`
 	CloudInit                 *bool                 `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string               `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	CloudInitDiskType         *string               `mapstructure:"cloud_init_disk_type" cty:"cloud_init_disk_type" hcl:"cloud_init_disk_type"`
@@ -236,6 +237,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
+		"skip_convert_to_template":     &hcldec.AttrSpec{Name: "skip_convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"cloud_init_disk_type":         &hcldec.AttrSpec{Name: "cloud_init_disk_type", Type: cty.String, Required: false},

--- a/builder/proxmox/common/step_convert_to_template.go
+++ b/builder/proxmox/common/step_convert_to_template.go
@@ -16,7 +16,7 @@ import (
 // stepConvertToTemplate takes the running VM configured in earlier steps, stops it, and
 // converts it into a Proxmox template.
 //
-// It sets the template_id state which is used for Artifact lookup.
+// It sets the artifact_id state which is used for Artifact lookup.
 type stepConvertToTemplate struct{}
 
 type templateConverter interface {
@@ -30,6 +30,7 @@ func (s *stepConvertToTemplate) Run(ctx context.Context, state multistep.StateBa
 	ui := state.Get("ui").(packersdk.Ui)
 	client := state.Get("proxmoxClient").(templateConverter)
 	vmRef := state.Get("vmRef").(*proxmox.VmRef)
+	c := state.Get("config").(*Config)
 
 	ui.Say("Stopping VM")
 	_, err := client.ShutdownVm(vmRef)
@@ -40,16 +41,23 @@ func (s *stepConvertToTemplate) Run(ctx context.Context, state multistep.StateBa
 		return multistep.ActionHalt
 	}
 
-	ui.Say("Converting VM to template")
-	err = client.CreateTemplate(vmRef)
-	if err != nil {
-		err := fmt.Errorf("Error converting VM to template: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
+	if c.SkipConvertToTemplate {
+		ui.Say("skip_convert_to_template set, skipping conversion to template")
+		state.Put("artifact_type", "VM")
+	} else {
+		ui.Say("Converting VM to template")
+		err = client.CreateTemplate(vmRef)
+		if err != nil {
+			err := fmt.Errorf("Error converting VM to template: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		state.Put("artifact_type", "template")
 	}
-	log.Printf("template_id: %d", vmRef.VmId())
-	state.Put("template_id", vmRef.VmId())
+
+	log.Printf("artifact_id: %d", vmRef.VmId())
+	state.Put("artifact_id", vmRef.VmId())
 
 	return multistep.ActionContinue
 }

--- a/builder/proxmox/common/step_convert_to_template.go
+++ b/builder/proxmox/common/step_convert_to_template.go
@@ -32,19 +32,19 @@ func (s *stepConvertToTemplate) Run(ctx context.Context, state multistep.StateBa
 	vmRef := state.Get("vmRef").(*proxmox.VmRef)
 	c := state.Get("config").(*Config)
 
-	ui.Say("Stopping VM")
-	_, err := client.ShutdownVm(vmRef)
-	if err != nil {
-		err := fmt.Errorf("Error converting VM to template, could not stop: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-
 	if c.SkipConvertToTemplate {
 		ui.Say("skip_convert_to_template set, skipping conversion to template")
 		state.Put("artifact_type", "VM")
 	} else {
+		ui.Say("Stopping VM")
+		_, err := client.ShutdownVm(vmRef)
+		if err != nil {
+			err := fmt.Errorf("Error converting VM to template, could not stop: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
 		ui.Say("Converting VM to template")
 		err = client.CreateTemplate(vmRef)
 		if err != nil {

--- a/builder/proxmox/common/step_convert_to_template_test.go
+++ b/builder/proxmox/common/step_convert_to_template_test.go
@@ -34,27 +34,45 @@ func TestConvertToTemplate(t *testing.T) {
 		expectCallCreateTemplate bool
 		createTemplateErr        error
 		expectedAction           multistep.StepAction
-		expectTemplateIdSet      bool
+		expectArtifactIdSet      bool
+		expectArtifactType       string
+		builderConfig            *Config
 	}{
 		{
 			name:                     "no errors returns continue and sets template id",
 			expectCallCreateTemplate: true,
 			expectedAction:           multistep.ActionContinue,
-			expectTemplateIdSet:      true,
+			expectArtifactIdSet:      true,
+			expectArtifactType:       "template",
+			builderConfig:            &Config{},
+		},
+		{
+			name:                     "no errors returns continue and sets vm id",
+			expectCallCreateTemplate: true,
+			expectedAction:           multistep.ActionContinue,
+			expectArtifactIdSet:      true,
+			expectArtifactType:       "VM",
+			builderConfig: &Config{
+				SkipConvertToTemplate: true,
+			},
 		},
 		{
 			name:                     "when shutdown fails, don't try to create template and halt",
 			shutdownErr:              fmt.Errorf("failed to stop vm"),
 			expectCallCreateTemplate: false,
 			expectedAction:           multistep.ActionHalt,
-			expectTemplateIdSet:      false,
+			expectArtifactIdSet:      false,
+			expectArtifactType:       "",
+			builderConfig:            &Config{},
 		},
 		{
 			name:                     "when create template fails, halt",
 			expectCallCreateTemplate: true,
 			createTemplateErr:        fmt.Errorf("failed to stop vm"),
 			expectedAction:           multistep.ActionHalt,
-			expectTemplateIdSet:      false,
+			expectArtifactIdSet:      false,
+			expectArtifactType:       "",
+			builderConfig:            &Config{},
 		},
 	}
 
@@ -85,6 +103,7 @@ func TestConvertToTemplate(t *testing.T) {
 			state.Put("ui", packersdk.TestUi(t))
 			state.Put("vmRef", proxmox.NewVmRef(vmid))
 			state.Put("proxmoxClient", converter)
+			state.Put("config", c.builderConfig)
 
 			step := stepConvertToTemplate{}
 			action := step.Run(context.TODO(), state)
@@ -92,14 +111,23 @@ func TestConvertToTemplate(t *testing.T) {
 				t.Errorf("Expected action to be %v, got %v", c.expectedAction, action)
 			}
 
-			id, wasSet := state.GetOk("template_id")
+			artifactId, artifactIdWasSet := state.GetOk("artifact_id")
+			artifactType, artifactTypeWasSet := state.GetOk("artifact_type")
 
-			if c.expectTemplateIdSet != wasSet {
-				t.Errorf("Expected template_id state present=%v was present=%v", c.expectTemplateIdSet, wasSet)
+			if c.expectArtifactIdSet != artifactIdWasSet {
+				t.Errorf("Expected artifact_id state present=%v was present=%v", c.expectArtifactIdSet, artifactIdWasSet)
 			}
 
-			if c.expectTemplateIdSet && id != vmid {
-				t.Errorf("Expected template_id state to be set to %d, got %v", vmid, id)
+			if c.expectArtifactIdSet && artifactId != vmid {
+				t.Errorf("Expected artifact_id state to be set to %d, got %v", vmid, artifactId)
+			}
+
+			if c.expectArtifactType == "" && artifactTypeWasSet {
+				t.Errorf("Expected artifact_type state present=%v was present=%v", c.expectArtifactType, artifactTypeWasSet)
+			}
+
+			if artifactTypeWasSet && c.expectArtifactType != artifactType {
+				t.Errorf("Expected artifact_type state to be set to %s, got %s", c.expectArtifactType, artifactType)
 			}
 		})
 	}

--- a/builder/proxmox/common/step_finalize_config.go
+++ b/builder/proxmox/common/step_finalize_config.go
@@ -146,7 +146,7 @@ func (s *stepFinalizeConfig) Run(ctx context.Context, state multistep.StateBag) 
 			ui.Say("Hardware changes pending for VM, stopping VM")
 			_, err := client.ShutdownVm(vmRef)
 			if err != nil {
-				err := fmt.Errorf("Error converting VM to template, could not stop: %s", err)
+				err := fmt.Errorf("Error stopping VM: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt

--- a/builder/proxmox/common/step_finalize_config.go
+++ b/builder/proxmox/common/step_finalize_config.go
@@ -17,18 +17,19 @@ import (
 // stepFinalizeTemplateConfig does any required modifications to the configuration _after_
 // the VM has been converted into a template, such as updating name and description, or
 // unmounting the installation ISO.
-type stepFinalizeTemplateConfig struct{}
+type stepFinalizeConfig struct{}
 
-type templateFinalizer interface {
+type finalizer interface {
 	GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error)
 	SetVmConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error)
+	StartVm(*proxmox.VmRef) (string, error)
 }
 
-var _ templateFinalizer = &proxmox.Client{}
+var _ finalizer = &proxmox.Client{}
 
-func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepFinalizeConfig) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
-	client := state.Get("proxmoxClient").(templateFinalizer)
+	client := state.Get("proxmoxClient").(finalizer)
 	c := state.Get("config").(*Config)
 	vmRef := state.Get("vmRef").(*proxmox.VmRef)
 
@@ -151,4 +152,4 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 	return multistep.ActionContinue
 }
 
-func (s *stepFinalizeTemplateConfig) Cleanup(state multistep.StateBag) {}
+func (s *stepFinalizeConfig) Cleanup(state multistep.StateBag) {}

--- a/builder/proxmox/common/step_finalize_config_test.go
+++ b/builder/proxmox/common/step_finalize_config_test.go
@@ -18,6 +18,7 @@ import (
 type finalizerMock struct {
 	getConfig func() (map[string]interface{}, error)
 	setConfig func(map[string]interface{}) (string, error)
+	startVm   func() (string, error)
 }
 
 func (m finalizerMock) GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error) {
@@ -27,7 +28,11 @@ func (m finalizerMock) SetVmConfig(vmref *proxmox.VmRef, c map[string]interface{
 	return m.setConfig(c)
 }
 
-var _ templateFinalizer = finalizerMock{}
+func (m finalizerMock) StartVm(*proxmox.VmRef) (string, error) {
+	return m.startVm()
+}
+
+var _ finalizer = finalizerMock{}
 
 func TestTemplateFinalize(t *testing.T) {
 	cs := []struct {
@@ -218,7 +223,7 @@ func TestTemplateFinalize(t *testing.T) {
 			state.Put("vmRef", proxmox.NewVmRef(1))
 			state.Put("proxmoxClient", finalizer)
 
-			step := stepFinalizeTemplateConfig{}
+			step := stepFinalizeConfig{}
 			action := step.Run(context.TODO(), state)
 			if action != c.expectedAction {
 				t.Errorf("Expected action to be %v, got %v", c.expectedAction, action)

--- a/builder/proxmox/common/step_finalize_config_test.go
+++ b/builder/proxmox/common/step_finalize_config_test.go
@@ -16,9 +16,10 @@ import (
 )
 
 type finalizerMock struct {
-	getConfig func() (map[string]interface{}, error)
-	setConfig func(map[string]interface{}) (string, error)
-	startVm   func() (string, error)
+	getConfig  func() (map[string]interface{}, error)
+	setConfig  func(map[string]interface{}) (string, error)
+	startVm    func() (string, error)
+	shutdownVm func() (string, error)
 }
 
 func (m finalizerMock) GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error) {
@@ -30,6 +31,10 @@ func (m finalizerMock) SetVmConfig(vmref *proxmox.VmRef, c map[string]interface{
 
 func (m finalizerMock) StartVm(*proxmox.VmRef) (string, error) {
 	return m.startVm()
+}
+
+func (m finalizerMock) ShutdownVm(*proxmox.VmRef) (string, error) {
+	return m.shutdownVm()
 }
 
 var _ finalizer = finalizerMock{}

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -36,7 +36,9 @@ type vmStarter interface {
 	GetVmConfig(vmr *proxmox.VmRef) (vmConfig map[string]interface{}, err error)
 	GetVmRefsByName(vmName string) (vmrs []*proxmox.VmRef, err error)
 	SetVmConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error)
+	GetVmState(vmr *proxmox.VmRef) (vmState map[string]interface{}, err error)
 	StartVm(*proxmox.VmRef) (string, error)
+	StopVm(*proxmox.VmRef) (string, error)
 }
 
 var (
@@ -45,7 +47,7 @@ var (
 
 // Check if the given builder configuration maps to an existing VM template on the Proxmox cluster.
 // Returns an empty *proxmox.VmRef when no matching ID or name is found.
-func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
+func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, string, error) {
 	vmRef := &proxmox.VmRef{}
 	if c.VMID > 0 {
 		log.Printf("looking up VM with ID %d", c.VMID)
@@ -57,9 +59,9 @@ func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
 			notFoundError := fmt.Sprintf("vm '%d' not found", c.VMID)
 			if err.Error() == notFoundError {
 				log.Println(err.Error())
-				return &proxmox.VmRef{}, nil
+				return &proxmox.VmRef{}, "", nil
 			}
-			return &proxmox.VmRef{}, err
+			return &proxmox.VmRef{}, "", err
 		}
 		log.Printf("found VM with ID %d", vmRef.VmId())
 	} else {
@@ -71,30 +73,33 @@ func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
 			notFoundError := fmt.Sprintf("vm '%s' not found", c.TemplateName)
 			if err.Error() == notFoundError {
 				log.Println(err.Error())
-				return &proxmox.VmRef{}, nil
+				return &proxmox.VmRef{}, "", nil
 			}
-			return &proxmox.VmRef{}, err
+			return &proxmox.VmRef{}, "", err
 		}
 		if len(vmRefs) > 1 {
 			vmIDs := []int{}
 			for _, vmr := range vmRefs {
 				vmIDs = append(vmIDs, vmr.VmId())
 			}
-			return &proxmox.VmRef{}, fmt.Errorf("found multiple VMs with name '%s', IDs: %v", c.TemplateName, vmIDs)
+			return &proxmox.VmRef{}, "", fmt.Errorf("found multiple VMs with name '%s', IDs: %v", c.TemplateName, vmIDs)
 		}
 		vmRef = vmRefs[0]
 		log.Printf("found VM with name '%s' (ID: %d)", c.TemplateName, vmRef.VmId())
 	}
+	if c.SkipConvertToTemplate {
+		return vmRef, "VM", nil
+	}
 	log.Printf("check if VM %d is a template", vmRef.VmId())
 	vmConfig, err := client.GetVmConfig(vmRef)
 	if err != nil {
-		return &proxmox.VmRef{}, err
+		return &proxmox.VmRef{}, "", err
 	}
 	log.Printf("VM %d template: %d", vmRef.VmId(), vmConfig["template"])
 	if vmConfig["template"] == nil {
-		return &proxmox.VmRef{}, fmt.Errorf("found matching VM (ID: %d, name: %s), but it is not a template", vmRef.VmId(), vmConfig["name"])
+		return &proxmox.VmRef{}, "", fmt.Errorf("found matching VM (ID: %d, name: %s), but it is not a template", vmRef.VmId(), vmConfig["name"])
 	}
-	return vmRef, nil
+	return vmRef, "VM template", nil
 }
 
 func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -162,21 +167,38 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 
 	if c.PackerForce {
 		ui.Say("Force set, checking for existing artifact on PVE cluster")
-		vmRef, err := getExistingTemplate(c, client)
+		vmRef, vmType, err := getExistingTemplate(c, client)
 		if err != nil {
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
 		if vmRef.VmId() != 0 {
-			ui.Say(fmt.Sprintf("found existing VM template with ID %d on PVE node %s, deleting it", vmRef.VmId(), vmRef.Node()))
+			ui.Say(fmt.Sprintf("found existing %s with ID %d on PVE node %s, deleting it", vmType, vmRef.VmId(), vmRef.Node()))
+			// If building a VM artifact and c.PackerForce is true,
+			// running VMs can't be deleted. Stop before deleting.
+			vmState, err := client.GetVmState(vmRef)
+			if err != nil {
+				state.Put("error", err)
+				ui.Error(fmt.Sprintf("error getting VM state: %s", err.Error()))
+				return multistep.ActionHalt
+			}
+			if vmState["status"] == "running" {
+				log.Printf("VM %d running, stopping for deletion", vmRef.VmId())
+				_, err = client.StopVm(vmRef)
+				if err != nil {
+					state.Put("error", err)
+					ui.Error(fmt.Sprintf("error stopping %s: %s", vmType, err.Error()))
+					return multistep.ActionHalt
+				}
+			}
 			_, err = client.DeleteVm(vmRef)
 			if err != nil {
 				state.Put("error", err)
-				ui.Error(fmt.Sprintf("error deleting VM template: %s", err.Error()))
+				ui.Error(fmt.Sprintf("error deleting %s: %s", vmType, err.Error()))
 				return multistep.ActionHalt
 			}
-			ui.Say(fmt.Sprintf("Successfully deleted VM template %d", vmRef.VmId()))
+			ui.Say(fmt.Sprintf("Successfully deleted %s %d", vmType, vmRef.VmId()))
 		} else {
 			ui.Say("No existing artifact found")
 		}

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -114,6 +114,7 @@ type FlatConfig struct {
 	DisableKVM                *bool                         `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
 	TemplateName              *string                       `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	TemplateDescription       *string                       `mapstructure:"template_description" cty:"template_description" hcl:"template_description"`
+	SkipConvertToTemplate     *bool                         `mapstructure:"skip_convert_to_template" cty:"skip_convert_to_template" hcl:"skip_convert_to_template"`
 	CloudInit                 *bool                         `mapstructure:"cloud_init" cty:"cloud_init" hcl:"cloud_init"`
 	CloudInitStoragePool      *string                       `mapstructure:"cloud_init_storage_pool" cty:"cloud_init_storage_pool" hcl:"cloud_init_storage_pool"`
 	CloudInitDiskType         *string                       `mapstructure:"cloud_init_disk_type" cty:"cloud_init_disk_type" hcl:"cloud_init_disk_type"`
@@ -247,6 +248,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
+		"skip_convert_to_template":     &hcldec.AttrSpec{Name: "skip_convert_to_template", Type: cty.Bool, Required: false},
 		"cloud_init":                   &hcldec.AttrSpec{Name: "cloud_init", Type: cty.Bool, Required: false},
 		"cloud_init_storage_pool":      &hcldec.AttrSpec{Name: "cloud_init_storage_pool", Type: cty.String, Required: false},
 		"cloud_init_disk_type":         &hcldec.AttrSpec{Name: "cloud_init_disk_type", Type: cty.String, Required: false},

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -125,6 +125,9 @@
 - `template_description` (string) - Description of the template, visible in
   the Proxmox interface.
 
+- `skip_convert_to_template` (bool) - Skip converting the VM to a template on completion of build.
+  Defaults to `false`
+
 - `cloud_init` (bool) - If true, add an empty Cloud-Init CDROM drive after the virtual
   machine has been converted to a template. Defaults to `false`.
 


### PR DESCRIPTION
Rewrite of #72 on current codebase.

Implements config option skip_convert_to_template which skips converting the build to a Template and leaves the build artifact as a VM.

Closes #71
