### PR TITLE
[Issue 285] Fix tags regression

### DIFF
--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -119,6 +119,8 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		}
 	}
 
+	var description = "Packer ephemeral build VM"
+
 	config := proxmox.ConfigQemu{
 		Name:           c.VMName,
 		Agent:          generateAgentConfig(c.Agent),
@@ -126,7 +128,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Tags:           generateTags(c.Tags),
 		Boot:           c.Boot, // Boot priority, example: "order=virtio0;ide2;net0", virtio0:Disk0 -> ide0:CDROM -> net0:Network
 		QemuCpu:        c.CPUType,
-		Description:    "Packer ephemeral build VM",
+		Description:    &description,
 		Memory:         c.Memory,
 		QemuCores:      c.Cores,
 		QemuSockets:    c.Sockets,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/packer-plugin-proxmox
 go 1.21.0
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20240525163725-6676d8933df0
+	github.com/Telmate/proxmox-api-go v0.0.0-20240726134822-4c4580d03d9e
 	github.com/hashicorp/go-getter/v2 v2.2.2
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/packer-plugin-sdk v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,10 @@ github.com/Telmate/proxmox-api-go v0.0.0-20240409105641-32c480fe008e h1:NdpVflh7
 github.com/Telmate/proxmox-api-go v0.0.0-20240409105641-32c480fe008e/go.mod h1:bscBzOUx0tJAdVGmQvcnoWPg5eI2eJ6anJKV1ueZ1oU=
 github.com/Telmate/proxmox-api-go v0.0.0-20240525163725-6676d8933df0 h1:VK35Q0s1IayA2Nwm0uREu+LVs0WWPq9Zsn3Oic1q5eg=
 github.com/Telmate/proxmox-api-go v0.0.0-20240525163725-6676d8933df0/go.mod h1:bscBzOUx0tJAdVGmQvcnoWPg5eI2eJ6anJKV1ueZ1oU=
+github.com/Telmate/proxmox-api-go v0.0.0-20240615154505-578dffaf4d38 h1:ViSuq1kQmOHycY8pvwDo319UwuuEnqhRXp4b0EiMJW4=
+github.com/Telmate/proxmox-api-go v0.0.0-20240615154505-578dffaf4d38/go.mod h1:bscBzOUx0tJAdVGmQvcnoWPg5eI2eJ6anJKV1ueZ1oU=
+github.com/Telmate/proxmox-api-go v0.0.0-20240726134822-4c4580d03d9e h1:e2StaFGv+J2yhCP29DBQmchLQHNqbCnLomZGx66p6/Q=
+github.com/Telmate/proxmox-api-go v0.0.0-20240726134822-4c4580d03d9e/go.mod h1:O6yNUi0hG9GQLMBgpikSvbnuek1OMweFtbac1sfGuUs=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
A regression was introduced by the proxmox-api-go which didn't allow hyphens in tags. Bumped proxmox-api-go to a version where hyphen support is reintroduced. Some other API changes had occurred between versions around cloud-init and the VM Description field which have been handled and tested.

Closes #285 

