### PR TITLE
[Issue 276] QEMU Agent configuration settings

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -243,9 +243,12 @@ boot time.
     ]
     ```
 
-- `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
+- `qemu_agent` (boolean) - DEPRECATED. Define QEMU Guest Agent settings in a `qemu_guest_agent` block instead.
+  Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
   `ssh_host` should be used. Defaults to `true`.
+
+- `qemu_guest_agent` (agentConfig) - QEMU Guest Agent configuration. See [QEMU Guest Agent](#qemu-guest-agent)
 
 - `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
@@ -824,6 +827,57 @@ Usage example (JSON):
   Defaults to `4m`.
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
+
+
+### QEMU Guest Agent
+
+<!-- Code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+Set the QEMU Guest Agent options.
+
+JSON Example:
+
+```json
+
+	"qemu_guest_agent": {
+			  "enabled": true,
+			  "type": "isa",
+			  "freeze": false,
+			  "fstrim": false
+	}
+
+```
+HCL2 example:
+
+```hcl
+
+	qemu_guest_agent {
+	  enabled = true
+	  type = "isa"
+	  freeze = false
+	  fstrim = false
+	}
+
+```
+
+<!-- End of code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; -->
+
+
+#### Optional:
+
+<!-- Code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `enabled` (boolean) - Enable QEMU Agent option for this VM. When enabled
+  `qemu-guest-agent` must be installed on the guest. When disabled
+  `ssh_host` should be used. Defaults to `true`.
+
+- `type` (string) - Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
+
+- `freeze` (boolean) - Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
+
+- `fstrim` (bool) - Run guest-trim after a disk move or VM migration. Defaults to `false`
+
+<!-- End of code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; -->
 
 
 ### VirtIO RNG device

--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -873,7 +873,7 @@ HCL2 example:
 
 - `type` (string) - Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
 
-- `freeze` (boolean) - Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
+- `disable_freeze` (bool) - Disable freeze/thaw of guest filesystem on backup. Defaults to `false`
 
 - `fstrim` (bool) - Run guest-trim after a disk move or VM migration. Defaults to `false`
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -714,7 +714,7 @@ HCL2 example:
 
 - `type` (string) - Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
 
-- `freeze` (boolean) - Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
+- `disable_freeze` (bool) - Disable freeze/thaw of guest filesystem on backup. Defaults to `false`
 
 - `fstrim` (bool) - Run guest-trim after a disk move or VM migration. Defaults to `false`
 

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -178,9 +178,12 @@ in the image's Cloud-Init settings for provisioning.
     ]
     ```
 
-- `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
+- `qemu_agent` (boolean) - DEPRECATED. Define QEMU Guest Agent settings in a `qemu_guest_agent` block instead.
+  Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
   `ssh_host` should be used. Defaults to `true`.
+
+- `qemu_guest_agent` (agentConfig) - QEMU Guest Agent configuration. See [QEMU Guest Agent](#qemu-guest-agent)
 
 - `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
@@ -665,6 +668,57 @@ Usage example (JSON):
   Defaults to `4m`.
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
+
+
+### QEMU Guest Agent
+
+<!-- Code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+Set the QEMU Guest Agent options.
+
+JSON Example:
+
+```json
+
+	"qemu_guest_agent": {
+			  "enabled": true,
+			  "type": "isa",
+			  "freeze": false,
+			  "fstrim": false
+	}
+
+```
+HCL2 example:
+
+```hcl
+
+	qemu_guest_agent {
+	  enabled = true
+	  type = "isa"
+	  freeze = false
+	  fstrim = false
+	}
+
+```
+
+<!-- End of code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; -->
+
+
+#### Optional:
+
+<!-- Code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `enabled` (boolean) - Enable QEMU Agent option for this VM. When enabled
+  `qemu-guest-agent` must be installed on the guest. When disabled
+  `ssh_host` should be used. Defaults to `true`.
+
+- `type` (string) - Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
+
+- `freeze` (boolean) - Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
+
+- `fstrim` (bool) - Run guest-trim after a disk move or VM migration. Defaults to `false`
+
+<!-- End of code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; -->
 
 
 ### VirtIO RNG device

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -109,6 +109,7 @@ type FlatConfig struct {
 	PCIDevices                []proxmox.FlatpciDeviceConfig `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                   []string                      `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                         `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
+	GuestAgent                *proxmox.FlatagentConfig      `mapstructure:"qemu_guest_agent" cty:"qemu_guest_agent" hcl:"qemu_guest_agent"`
 	SCSIController            *string                       `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                    *bool                         `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
 	DisableKVM                *bool                         `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
@@ -238,6 +239,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pci_devices":                  &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*proxmox.FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
+		"qemu_guest_agent":             &hcldec.BlockSpec{TypeName: "qemu_guest_agent", Nested: hcldec.ObjectSpec((*proxmox.FlatagentConfig)(nil).HCL2Spec())},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                       &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -243,8 +243,8 @@ type agentConfig struct {
 	Enabled config.Trilean `mapstructure:"enabled"`
 	// Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
 	Type string `mapstructure:"type"`
-	// Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
-	Freeze config.Trilean `mapstructure:"freeze"`
+	// Disable freeze/thaw of guest filesystem on backup. Defaults to `false`
+	DisableFreeze bool `mapstructure:"disable_freeze"`
 	// Run guest-trim after a disk move or VM migration. Defaults to `false`
 	FsTrim bool `mapstructure:"fstrim"`
 }
@@ -646,20 +646,15 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		warnings = append(warnings, "proxmox is deprecated, please use proxmox-iso instead")
 	}
 
-	// Default qemu_agent to true
-	if c.Agent != config.TriFalse {
+	if c.Agent != config.TriUnset {
 		warnings = append(warnings, "qemu_agent is deprecated and will be removed in a future release. define QEMU agent settings in a qemu_guest_agent block instead")
 		// convert to qemu_guest_agent block value
-		c.GuestAgent.Enabled = config.TriTrue
+		c.GuestAgent.Enabled = c.Agent
 	}
 
 	// Default qemu_guest_agent.enable to true
 	if c.GuestAgent.Enabled != config.TriFalse {
 		c.GuestAgent.Enabled = config.TriTrue
-	}
-	// Default qemu_guest_agent.freeze to true
-	if c.GuestAgent.Freeze != config.TriFalse {
-		c.GuestAgent.Freeze = config.TriTrue
 	}
 
 	switch c.GuestAgent.Type {

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate packer-sdc struct-markdown
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config,NICConfig,diskConfig,rng0Config,pciDeviceConfig,vgaConfig,ISOsConfig,efiConfig,tpmConfig
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,NICConfig,diskConfig,rng0Config,pciDeviceConfig,vgaConfig,ISOsConfig,efiConfig,tpmConfig,agentConfig
 
 package proxmox
 
@@ -158,10 +158,13 @@ type Config struct {
 	//   ]
 	//   ```
 	Serials []string `mapstructure:"serials"`
+	// DEPRECATED. Define QEMU Guest Agent settings in a `qemu_guest_agent` block instead.
 	// Enables QEMU Agent option for this VM. When enabled,
 	// then `qemu-guest-agent` must be installed on the guest. When disabled, then
 	// `ssh_host` should be used. Defaults to `true`.
 	Agent config.Trilean `mapstructure:"qemu_agent"`
+	// QEMU Guest Agent configuration. See [QEMU Guest Agent](#qemu-guest-agent)
+	GuestAgent agentConfig `mapstructure:"qemu_guest_agent"`
 	// The SCSI controller model to emulate. Can be `lsi`,
 	// `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
 	// Defaults to `lsi`.
@@ -205,6 +208,45 @@ type Config struct {
 	CloneSourceDisks []string `mapstructure-to-hcl2:",skip"`
 
 	Ctx interpolate.Context `mapstructure-to-hcl2:",skip"`
+}
+
+// Set the QEMU Guest Agent options.
+//
+// JSON Example:
+//
+// ```json
+//
+//	"qemu_guest_agent": {
+//			  "enabled": true,
+//			  "type": "isa",
+//			  "freeze": false,
+//			  "fstrim": false
+//	}
+//
+// ```
+// HCL2 example:
+//
+// ```hcl
+//
+//	qemu_guest_agent {
+//	  enabled = true
+//	  type = "isa"
+//	  freeze = false
+//	  fstrim = false
+//	}
+//
+// ```
+type agentConfig struct {
+	// Enable QEMU Agent option for this VM. When enabled
+	// `qemu-guest-agent` must be installed on the guest. When disabled
+	// `ssh_host` should be used. Defaults to `true`.
+	Enabled config.Trilean `mapstructure:"enabled"`
+	// Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
+	Type string `mapstructure:"type"`
+	// Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
+	Freeze config.Trilean `mapstructure:"freeze"`
+	// Run guest-trim after a disk move or VM migration. Defaults to `false`
+	FsTrim bool `mapstructure:"fstrim"`
 }
 
 // ISO files attached to the virtual machine.
@@ -606,7 +648,27 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 
 	// Default qemu_agent to true
 	if c.Agent != config.TriFalse {
-		c.Agent = config.TriTrue
+		warnings = append(warnings, "qemu_agent is deprecated and will be removed in a future release. define QEMU agent settings in a qemu_guest_agent block instead")
+		// convert to qemu_guest_agent block value
+		c.GuestAgent.Enabled = config.TriTrue
+	}
+
+	// Default qemu_guest_agent.enable to true
+	if c.GuestAgent.Enabled != config.TriFalse {
+		c.GuestAgent.Enabled = config.TriTrue
+	}
+	// Default qemu_guest_agent.freeze to true
+	if c.GuestAgent.Freeze != config.TriFalse {
+		c.GuestAgent.Freeze = config.TriTrue
+	}
+
+	switch c.GuestAgent.Type {
+	case "virtio", "isa":
+	case "":
+		log.Printf("qemu_guest_agent type not specified, defaulting to `virtio`")
+		c.GuestAgent.Type = "virtio"
+	default:
+		errs = packersdk.MultiErrorAppend(errs, errors.New("qemu_guest_agent type field must be `virtio` or `isa`"))
 	}
 
 	packersdk.LogSecretFilter.Set(c.Password)

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -339,10 +339,10 @@ func (*FlatNICConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatagentConfig is an auto-generated flat version of agentConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatagentConfig struct {
-	Enabled *bool   `mapstructure:"enabled" cty:"enabled" hcl:"enabled"`
-	Type    *string `mapstructure:"type" cty:"type" hcl:"type"`
-	Freeze  *bool   `mapstructure:"freeze" cty:"freeze" hcl:"freeze"`
-	FsTrim  *bool   `mapstructure:"fstrim" cty:"fstrim" hcl:"fstrim"`
+	Enabled       *bool   `mapstructure:"enabled" cty:"enabled" hcl:"enabled"`
+	Type          *string `mapstructure:"type" cty:"type" hcl:"type"`
+	DisableFreeze *bool   `mapstructure:"disable_freeze" cty:"disable_freeze" hcl:"disable_freeze"`
+	FsTrim        *bool   `mapstructure:"fstrim" cty:"fstrim" hcl:"fstrim"`
 }
 
 // FlatMapstructure returns a new FlatagentConfig.
@@ -357,10 +357,10 @@ func (*agentConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.S
 // The decoded values from this spec will then be applied to a FlatagentConfig.
 func (*FlatagentConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"enabled": &hcldec.AttrSpec{Name: "enabled", Type: cty.Bool, Required: false},
-		"type":    &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
-		"freeze":  &hcldec.AttrSpec{Name: "freeze", Type: cty.Bool, Required: false},
-		"fstrim":  &hcldec.AttrSpec{Name: "fstrim", Type: cty.Bool, Required: false},
+		"enabled":        &hcldec.AttrSpec{Name: "enabled", Type: cty.Bool, Required: false},
+		"type":           &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
+		"disable_freeze": &hcldec.AttrSpec{Name: "disable_freeze", Type: cty.Bool, Required: false},
+		"fstrim":         &hcldec.AttrSpec{Name: "fstrim", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -108,6 +108,7 @@ type FlatConfig struct {
 	PCIDevices                []FlatpciDeviceConfig `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                   []string              `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                 `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
+	GuestAgent                *FlatagentConfig      `mapstructure:"qemu_guest_agent" cty:"qemu_guest_agent" hcl:"qemu_guest_agent"`
 	SCSIController            *string               `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                    *bool                 `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
 	DisableKVM                *bool                 `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
@@ -231,6 +232,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pci_devices":                  &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
+		"qemu_guest_agent":             &hcldec.BlockSpec{TypeName: "qemu_guest_agent", Nested: hcldec.ObjectSpec((*FlatagentConfig)(nil).HCL2Spec())},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                       &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},
@@ -330,6 +332,35 @@ func (*FlatNICConfig) HCL2Spec() map[string]hcldec.Spec {
 		"bridge":        &hcldec.AttrSpec{Name: "bridge", Type: cty.String, Required: false},
 		"vlan_tag":      &hcldec.AttrSpec{Name: "vlan_tag", Type: cty.String, Required: false},
 		"firewall":      &hcldec.AttrSpec{Name: "firewall", Type: cty.Bool, Required: false},
+	}
+	return s
+}
+
+// FlatagentConfig is an auto-generated flat version of agentConfig.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatagentConfig struct {
+	Enabled *bool   `mapstructure:"enabled" cty:"enabled" hcl:"enabled"`
+	Type    *string `mapstructure:"type" cty:"type" hcl:"type"`
+	Freeze  *bool   `mapstructure:"freeze" cty:"freeze" hcl:"freeze"`
+	FsTrim  *bool   `mapstructure:"fstrim" cty:"fstrim" hcl:"fstrim"`
+}
+
+// FlatMapstructure returns a new FlatagentConfig.
+// FlatagentConfig is an auto-generated flat version of agentConfig.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*agentConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatagentConfig)
+}
+
+// HCL2Spec returns the hcl spec of a agentConfig.
+// This spec is used by HCL to read the fields of agentConfig.
+// The decoded values from this spec will then be applied to a FlatagentConfig.
+func (*FlatagentConfig) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"enabled": &hcldec.AttrSpec{Name: "enabled", Type: cty.Bool, Required: false},
+		"type":    &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
+		"freeze":  &hcldec.AttrSpec{Name: "freeze", Type: cty.Bool, Required: false},
+		"fstrim":  &hcldec.AttrSpec{Name: "fstrim", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -63,6 +63,22 @@ func TestAgentSetToFalse(t *testing.T) {
 	}
 }
 
+func TestQemuAgentInvalidType(t *testing.T) {
+	cfg := mandatoryConfig(t)
+
+	agentCfg := make(map[string]interface{})
+	agentCfg["type"] = "qwerty"
+
+	cfg["qemu_guest_agent"] = agentCfg
+
+	var c Config
+	_, _, err := c.Prepare(&c, cfg)
+	// expect error, if none returned fail test
+	if err == nil {
+		t.Error("expected config preparation to fail, but no error occured")
+	}
+}
+
 func TestPacketQueueSupportForNetworkAdapters(t *testing.T) {
 	drivertests := []struct {
 		expectedToFail bool

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -256,9 +256,14 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 
 func generateAgentConfig(agent agentConfig) *proxmox.QemuGuestAgent {
 	var agentCfg proxmox.QemuGuestAgent
+	freeze := true
 
 	agentCfg.Enable = agent.Enabled.ToBoolPointer()
-	agentCfg.Freeze = agent.Freeze.ToBoolPointer()
+
+	if agent.DisableFreeze {
+		freeze = false
+	}
+	agentCfg.Freeze = &freeze
 
 	agentType := proxmox.QemuGuestAgentType(agent.Type)
 	agentCfg.Type = &agentType

--- a/builder/proxmox/common/step_start_vm_test.go
+++ b/builder/proxmox/common/step_start_vm_test.go
@@ -1329,10 +1329,10 @@ func TestGenerateQEMUAgentConfig(t *testing.T) {
 		{
 			"plain config, no special options set",
 			agentConfig{
-				Enabled: config.TriTrue,
-				Type:    "virtio",
-				Freeze:  config.TriTrue,
-				FsTrim:  false,
+				Enabled:       config.TriTrue,
+				Type:          "virtio",
+				DisableFreeze: false,
+				FsTrim:        false,
 			},
 			&proxmox.QemuGuestAgent{
 				Enable: boolPointer(true),
@@ -1344,10 +1344,10 @@ func TestGenerateQEMUAgentConfig(t *testing.T) {
 		{
 			"configure for isa type",
 			agentConfig{
-				Enabled: config.TriTrue,
-				Type:    "isa",
-				Freeze:  config.TriTrue,
-				FsTrim:  false,
+				Enabled:       config.TriTrue,
+				Type:          "isa",
+				DisableFreeze: false,
+				FsTrim:        false,
 			},
 			&proxmox.QemuGuestAgent{
 				Enable: boolPointer(true),
@@ -1359,10 +1359,10 @@ func TestGenerateQEMUAgentConfig(t *testing.T) {
 		{
 			"disable agent",
 			agentConfig{
-				Enabled: config.TriFalse,
-				Type:    "virtio",
-				Freeze:  config.TriTrue,
-				FsTrim:  false,
+				Enabled:       config.TriFalse,
+				Type:          "virtio",
+				DisableFreeze: false,
+				FsTrim:        false,
 			},
 			&proxmox.QemuGuestAgent{
 				Enable: boolPointer(false),
@@ -1374,10 +1374,10 @@ func TestGenerateQEMUAgentConfig(t *testing.T) {
 		{
 			"enable fstrim",
 			agentConfig{
-				Enabled: config.TriFalse,
-				Type:    "virtio",
-				Freeze:  config.TriTrue,
-				FsTrim:  true,
+				Enabled:       config.TriFalse,
+				Type:          "virtio",
+				DisableFreeze: false,
+				FsTrim:        true,
 			},
 			&proxmox.QemuGuestAgent{
 				Enable: boolPointer(false),
@@ -1389,10 +1389,10 @@ func TestGenerateQEMUAgentConfig(t *testing.T) {
 		{
 			"disable freeze",
 			agentConfig{
-				Enabled: config.TriTrue,
-				Type:    "virtio",
-				Freeze:  config.TriFalse,
-				FsTrim:  true,
+				Enabled:       config.TriTrue,
+				Type:          "virtio",
+				DisableFreeze: true,
+				FsTrim:        true,
 			},
 			&proxmox.QemuGuestAgent{
 				Enable: boolPointer(true),

--- a/builder/proxmox/common/step_start_vm_test.go
+++ b/builder/proxmox/common/step_start_vm_test.go
@@ -1389,15 +1389,15 @@ func TestGenerateQEMUAgentConfig(t *testing.T) {
 		{
 			"disable freeze",
 			agentConfig{
-				Enabled: config.TriFalse,
+				Enabled: config.TriTrue,
 				Type:    "virtio",
-				Freeze:  config.TriTrue,
+				Freeze:  config.TriFalse,
 				FsTrim:  true,
 			},
 			&proxmox.QemuGuestAgent{
-				Enable: boolPointer(false),
+				Enable: boolPointer(true),
 				Type:   qemuGuestAgentTypePointer("virtio"),
-				Freeze: boolPointer(true),
+				Freeze: boolPointer(false),
 				FsTrim: boolPointer(true),
 			},
 		},

--- a/builder/proxmox/common/step_start_vm_test.go
+++ b/builder/proxmox/common/step_start_vm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1306,6 +1307,107 @@ func TestGenerateProxmoxDisks(t *testing.T) {
 			if !tt.expectedToFail {
 				assert.Equal(t, devs, tt.expectOutput)
 			}
+		})
+	}
+}
+
+func boolPointer(b bool) *bool {
+	return &b
+}
+
+func qemuGuestAgentTypePointer(t proxmox.QemuGuestAgentType) *proxmox.QemuGuestAgentType {
+	return &t
+}
+
+func TestGenerateQEMUAgentConfig(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		agentConfig  agentConfig
+		expectOutput *proxmox.QemuGuestAgent
+	}{
+		{
+			"plain config, no special options set",
+			agentConfig{
+				Enabled: config.TriTrue,
+				Type:    "virtio",
+				Freeze:  config.TriTrue,
+				FsTrim:  false,
+			},
+			&proxmox.QemuGuestAgent{
+				Enable: boolPointer(true),
+				Type:   qemuGuestAgentTypePointer("virtio"),
+				Freeze: boolPointer(true),
+				FsTrim: boolPointer(false),
+			},
+		},
+		{
+			"configure for isa type",
+			agentConfig{
+				Enabled: config.TriTrue,
+				Type:    "isa",
+				Freeze:  config.TriTrue,
+				FsTrim:  false,
+			},
+			&proxmox.QemuGuestAgent{
+				Enable: boolPointer(true),
+				Type:   qemuGuestAgentTypePointer("isa"),
+				Freeze: boolPointer(true),
+				FsTrim: boolPointer(false),
+			},
+		},
+		{
+			"disable agent",
+			agentConfig{
+				Enabled: config.TriFalse,
+				Type:    "virtio",
+				Freeze:  config.TriTrue,
+				FsTrim:  false,
+			},
+			&proxmox.QemuGuestAgent{
+				Enable: boolPointer(false),
+				Type:   qemuGuestAgentTypePointer("virtio"),
+				Freeze: boolPointer(true),
+				FsTrim: boolPointer(false),
+			},
+		},
+		{
+			"enable fstrim",
+			agentConfig{
+				Enabled: config.TriFalse,
+				Type:    "virtio",
+				Freeze:  config.TriTrue,
+				FsTrim:  true,
+			},
+			&proxmox.QemuGuestAgent{
+				Enable: boolPointer(false),
+				Type:   qemuGuestAgentTypePointer("virtio"),
+				Freeze: boolPointer(true),
+				FsTrim: boolPointer(true),
+			},
+		},
+		{
+			"disable freeze",
+			agentConfig{
+				Enabled: config.TriFalse,
+				Type:    "virtio",
+				Freeze:  config.TriTrue,
+				FsTrim:  true,
+			},
+			&proxmox.QemuGuestAgent{
+				Enable: boolPointer(false),
+				Type:   qemuGuestAgentTypePointer("virtio"),
+				Freeze: boolPointer(true),
+				FsTrim: boolPointer(true),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentCfg := generateAgentConfig(tt.agentConfig)
+
+			assert.Equal(t, agentCfg, tt.expectOutput)
 		})
 	}
 }

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -109,6 +109,7 @@ type FlatConfig struct {
 	PCIDevices                []proxmox.FlatpciDeviceConfig `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                   []string                      `mapstructure:"serials" cty:"serials" hcl:"serials"`
 	Agent                     *bool                         `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
+	GuestAgent                *proxmox.FlatagentConfig      `mapstructure:"qemu_guest_agent" cty:"qemu_guest_agent" hcl:"qemu_guest_agent"`
 	SCSIController            *string                       `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                    *bool                         `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
 	DisableKVM                *bool                         `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
@@ -242,6 +243,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pci_devices":                  &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*proxmox.FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                      &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
+		"qemu_guest_agent":             &hcldec.BlockSpec{TypeName: "qemu_guest_agent", Nested: hcldec.ObjectSpec((*proxmox.FlatagentConfig)(nil).HCL2Spec())},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                       &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},
 		"disable_kvm":                  &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},

--- a/builder/proxmox/iso/config_test.go
+++ b/builder/proxmox/iso/config_test.go
@@ -103,7 +103,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)
 	}
-	if b.config.GuestAgent.Enabled.True() != true {
+	if !b.config.GuestAgent.Enabled.True() {
 		t.Errorf("Expected Agent to be true, got %t", b.config.GuestAgent.Enabled.True())
 	}
 	if b.config.DisableKVM != false {

--- a/builder/proxmox/iso/config_test.go
+++ b/builder/proxmox/iso/config_test.go
@@ -103,8 +103,8 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)
 	}
-	if b.config.Agent.True() != true {
-		t.Errorf("Expected Agent to be true, got %t", b.config.Agent.True())
+	if b.config.GuestAgent.Enabled.True() != true {
+		t.Errorf("Expected Agent to be true, got %t", b.config.GuestAgent.Enabled.True())
 	}
 	if b.config.DisableKVM != false {
 		t.Errorf("Expected Disable KVM toggle to be false, got %t", b.config.DisableKVM)

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -106,9 +106,12 @@
     ]
     ```
 
-- `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
+- `qemu_agent` (boolean) - DEPRECATED. Define QEMU Guest Agent settings in a `qemu_guest_agent` block instead.
+  Enables QEMU Agent option for this VM. When enabled,
   then `qemu-guest-agent` must be installed on the guest. When disabled, then
   `ssh_host` should be used. Defaults to `true`.
+
+- `qemu_guest_agent` (agentConfig) - QEMU Guest Agent configuration. See [QEMU Guest Agent](#qemu-guest-agent)
 
 - `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.

--- a/docs-partials/builder/proxmox/common/agentConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/agentConfig-not-required.mdx
@@ -1,0 +1,13 @@
+<!-- Code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `enabled` (boolean) - Enable QEMU Agent option for this VM. When enabled
+  `qemu-guest-agent` must be installed on the guest. When disabled
+  `ssh_host` should be used. Defaults to `true`.
+
+- `type` (string) - Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
+
+- `freeze` (boolean) - Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
+
+- `fstrim` (bool) - Run guest-trim after a disk move or VM migration. Defaults to `false`
+
+<!-- End of code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/agentConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/agentConfig-not-required.mdx
@@ -6,7 +6,7 @@
 
 - `type` (string) - Sets the Agent Type. Must be `isa` or `virtio`. Defaults to `virtio`
 
-- `freeze` (boolean) - Enable freeze/thaw of guest filesystem on backup. Defaults to `true`
+- `disable_freeze` (bool) - Disable freeze/thaw of guest filesystem on backup. Defaults to `false`
 
 - `fstrim` (bool) - Run guest-trim after a disk move or VM migration. Defaults to `false`
 

--- a/docs-partials/builder/proxmox/common/agentConfig.mdx
+++ b/docs-partials/builder/proxmox/common/agentConfig.mdx
@@ -1,0 +1,30 @@
+<!-- Code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+Set the QEMU Guest Agent options.
+
+JSON Example:
+
+```json
+
+	"qemu_guest_agent": {
+			  "enabled": true,
+			  "type": "isa",
+			  "freeze": false,
+			  "fstrim": false
+	}
+
+```
+HCL2 example:
+
+```hcl
+
+	qemu_guest_agent {
+	  enabled = true
+	  type = "isa"
+	  freeze = false
+	  fstrim = false
+	}
+
+```
+
+<!-- End of code generated from the comments of the agentConfig struct in builder/proxmox/common/config.go; -->

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -103,6 +103,14 @@ to you to use it or delete it.
 
 @include 'builder/proxmox/common/efiConfig-not-required.mdx'
 
+### QEMU Guest Agent
+
+@include 'builder/proxmox/common/agentConfig.mdx'
+
+#### Optional:
+
+@include 'builder/proxmox/common/agentConfig-not-required.mdx'
+
 ### VirtIO RNG device
 
 @include 'builder/proxmox/common/rng0Config.mdx'

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -90,6 +90,14 @@ to you to use it or delete it.
 
 @include 'builder/proxmox/common/efiConfig-not-required.mdx'
 
+### QEMU Guest Agent
+
+@include 'builder/proxmox/common/agentConfig.mdx'
+
+#### Optional:
+
+@include 'builder/proxmox/common/agentConfig-not-required.mdx'
+
 ### VirtIO RNG device
 
 @include 'builder/proxmox/common/rng0Config.mdx'


### PR DESCRIPTION
Extend QEMU agent handling by introducing the `qemu_quest_agent` block

`qemu_guest_agent` adds the ability to set each of the QEMU Guest Agent's available settings:
- Enable/Disable the agent (replaces the `qemu_agent` bool)
- Setting the agent type
- Toggling freeze/thaw filesystems on backup
- Toggling fstrim after disk move or VM migration

Each added setting defaults to Proxmox's backend defaults when not configured.


Closes #276 


