### PR TITLE
[Issue 291]: Handle disk format default

### DIFF
--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -781,6 +781,10 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 			log.Printf("Disk %d type not set, using default 'scsi'", idx)
 			c.Disks[idx].Type = "scsi"
 		}
+		if disk.DiskFormat == "" {
+			log.Printf("Disk %d format not set, using default 'raw'", idx)
+			c.Disks[idx].DiskFormat = "raw"
+		}
 		if disk.Size == "" {
 			log.Printf("Disk %d size not set, using default '20G'", idx)
 			c.Disks[idx].Size = "20G"


### PR DESCRIPTION
The `proxmox-api-go` version used in 1.2.1 now requires a disk format to be passed to it rather than falling back to Proxmox backend defaults when omitted. 

Add a default `format` value of `raw` in line with previous versions of the plugin

Closes #291 

