### PR TITLE
add HTTPCallbackAddress, needed when running within a kubernetes cluster

### DIFF
--- a/builder/proxmox/common/step_type_boot_command.go
+++ b/builder/proxmox/common/step_type_boot_command.go
@@ -58,7 +58,10 @@ func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 	}
 	var httpIP string
 	var err error
-	if c.HTTPAddress != "0.0.0.0" {
+	if c.HTTPCallbackAddress != "" {
+		// HTTPCallbackAddress is useful when running within a kubernetes environment using an exposed LoadBalancer ip
+		httpIP = c.HTTPCallbackAddress
+	} else if c.HTTPAddress != "0.0.0.0" {
 		httpIP = c.HTTPAddress
 	} else {
 		httpIP, err = hostIP(c.HTTPInterface)


### PR DESCRIPTION
#### Describe the change you are making here!

When running within a kubernetes workflow/pipelines, the http server used by the vm to communicate back completion cannot be reached directly. Instead, with kubernetes you 'expose' a pod via a LoadBalancer ip or ingress. The exposed ip is available but must be passed in somehow in order for it to be used.

This pull request implements the use of a variable HTTPCallbackAddress, which if provided, is passed along to the vm to be used upon completion when calling back to the http server.

A pull request has been submitted to the packer-plugin-sdk to add the needed variable:  https://github.com/hashicorp/packer-plugin-sdk/pull/268

#### Please include tests. Check out existent tests in the code for example.

I am open to what tests would be useful to add.  The code change is very small, and it might be fair to say if there is a test for HTTPAddress, and it is passing, that might be good enough to verify this implementation as well.

#### If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes: #304


