### PR TITLE
Broaden check for duplicate VM IDs to prevent race condition

### DIFF
--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -778,7 +778,7 @@ func setDeviceParamIfDefined(dev proxmox.QemuDevice, key, value string) {
 }
 
 func isDuplicateIDError(err error) bool {
-	return strings.Contains(err.Error(), "already exists on node")
+	return strings.Contains(err.Error(), "already exists")
 }
 
 type startedVMCleaner interface {


### PR DESCRIPTION
The test case doesn't appear to work for all cases as shown in #315, I've broadened it to include `config file already exists` as well.

Ideally the VMs should allocate IDs within the plugin by seeing what's available and pre-choosing them, rather than allowing proxmox to do so, I think the current retry system is a little bit messy. But I'm not really at liberty to rewrite that for you at the moment.

Closes #315

