### PR TITLE
IPv6 support for the proxmox builder.

### DIFF
--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -176,10 +176,15 @@ func getVMIP(state multistep.StateBag) (string, error) {
 
 	for _, iface := range ifs {
 		for _, addr := range iface.IpAddresses {
-			if addr.IsLoopback() {
+			if addr.To4() == nil && addr.To16() == nil {
+				// no IPv4 or IPv6 at all
 				continue
-			}
-			if addr.To4() == nil {
+			} else if addr.IsLinkLocalUnicast() || addr.IsMulticast() || addr.IsLoopback() || addr.IsUnspecified() {
+				// can not be replaced by !addr.IsGlobalUnicast() because it just returns ips wich are globally routable,
+				// but Unique Local Addresses: fc00::/7 can be used as well for IPv6 setups.
+				// SiteLocalUnicast: fec0::/10
+				// multicast: ff00::/8
+				// LinkLocalUnicat: fe80::/64
 				continue
 			}
 			return addr.String(), nil


### PR DESCRIPTION
Hey folks,

I added support for IPv6 and IPv4 dual stack setups or IPv6 only setups. The commit messages explains a lot for that reason I just copy the message to the description. I hope I didn't miss anything necessary and the PR can be discussed and reviewed.

It first checks for a valid IPv6 or IPv4 and continues if it's not valid. After that it continues if the ip is part of linkLocalUnicat, Multicast or loopback. The first ip which doesn't match one of the following types will be returned as valid.
no IPv4 or IPv6 at all
SiteLocalUnicast: fec0::/10
multicast: ff00::/8
LinkLocalUnicat: fe80::/64

If the proxmox interface supports IPv4 and IPv6 the selected ip depends on the proxmox list sorting of the returned addresses. The first valid ip will be used which can change depending on the proxmox api.

related to #233 
related to #10227
related to #10858