### PR TITLE
Adds support for resizing cloned disks

### DIFF
--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -340,7 +340,10 @@ type NICConfig struct {
 type diskConfig struct {
 	// The type of disk. Can be `scsi`, `sata`, `virtio` or
 	// `ide`. Defaults to `scsi`.
-	Type string `mapstructure:"type"`
+	Type  string `mapstructure:"type"`
+	// Optional: Used to specify the index of a disk. Can be used in combination
+	// with `type` and `size` to resize disks inherited from a cloned VM
+	Index string `mapstructure:"index" required:"false"`
 	// Required. Name of the Proxmox storage pool
 	// to store the virtual machine disk on. A `local-lvm` pool is allocated
 	// by the installer, for example.
@@ -569,7 +572,7 @@ type pciDeviceConfig struct {
 	HideROMBAR bool `mapstructure:"hide_rombar"`
 	// Custom PCI device rom filename (must be located in `/usr/share/kvm/`).
 	ROMFile string `mapstructure:"romfile"`
-	//Override PCI subsystem device ID visible to guest.
+	// Override PCI subsystem device ID visible to guest.
 	SubDeviceID string `mapstructure:"sub_device_id"`
 	// Override PCI subsystem vendor ID visible to guest.
 	SubVendorID string `mapstructure:"sub_vendor_id"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -340,6 +340,7 @@ func (*FlatNICConfig) HCL2Spec() map[string]hcldec.Spec {
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatdiskConfig struct {
 	Type              *string `mapstructure:"type" cty:"type" hcl:"type"`
+	Index             *string `mapstructure:"index" required:"false" cty:"index" hcl:"index"`
 	StoragePool       *string `mapstructure:"storage_pool" cty:"storage_pool" hcl:"storage_pool"`
 	StoragePoolType   *string `mapstructure:"storage_pool_type" cty:"storage_pool_type" hcl:"storage_pool_type"`
 	Size              *string `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
@@ -365,6 +366,7 @@ func (*diskConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Sp
 func (*FlatdiskConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"type":                &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
+		"index":               &hcldec.AttrSpec{Name: "index", Type: cty.String, Required: false},
 		"storage_pool":        &hcldec.AttrSpec{Name: "storage_pool", Type: cty.String, Required: false},
 		"storage_pool_type":   &hcldec.AttrSpec{Name: "storage_pool_type", Type: cty.String, Required: false},
 		"disk_size":           &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -314,11 +314,6 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 		VirtIO: &virtIODisks,
 	}
 
-	ideCount := 0
-	sataCount := 0
-	scsiCount := 0
-	virtIOCount := 0
-
 	var errs *packersdk.MultiError
 	var warnings []string
 
@@ -404,7 +399,7 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 					}
 					deviceIndex := fmt.Sprintf("scsi%s", isos[idx].Index)
 					log.Printf("Mapping static assigned ISO to %s", deviceIndex)
-					if slices.Contains(cloneSourceDisks, fmt.Sprintf("scsi%d", scsiCount)) {
+					if slices.Contains(cloneSourceDisks, fmt.Sprintf("scsi%d", isos[idx].Index)) {
 						warnings = append(warnings, fmt.Sprintf("an existing hard disk was found at %s on the clone source VM, overwriting with ISO configured for the same address", deviceIndex))
 					}
 					reflect.
@@ -436,6 +431,17 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 			backup = false
 		}
 
+		diskIndex := 0
+		overwrite := false
+		if disks[idx].Index != "" {
+			tmpInt, err := strconv.Atoi(disks[idx].Index)
+			if err != nil {
+				warnings = append(warnings, "disk index could not be converted to an integer, proceeding with 0")
+			} else {
+				diskIndex = tmpInt
+			}
+			overwrite = true
+		}
 		switch disks[idx].Type {
 		case "ide":
 			dev := proxmox.QemuIdeStorage{
@@ -451,30 +457,32 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 				},
 			}
 			for {
-				log.Printf("Mapping Disk to ide%d", ideCount)
+				log.Printf("Mapping Disk to ide%d", diskIndex)
 				// If IDE has too many devices attached pass an error then exit the loop
-				if ideCount > 3 {
-					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("storage enumeration reached ide index %d, too many ide devices configured. Ensure total Disk and ISO ide assignments don't exceed 4 devices", ideCount))
+				if diskIndex > 3 {
+					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("storage enumeration reached ide index %d, too many ide devices configured. Ensure total Disk and ISO ide assignments don't exceed 4 devices", diskIndex))
 					break
 				}
 
 				// If this ide device index isn't occupied by a disk on a clone builder source vm
-				if !slices.Contains(cloneSourceDisks, fmt.Sprintf("ide%d", ideCount)) &&
+				// If index was explicitly set, proceed regardless
+				// (telmate/proxmox-api-go detects the conflict and adjusts rather than replaces the existing disk)
+				if overwrite || !slices.Contains(cloneSourceDisks, fmt.Sprintf("ide%d", diskIndex)) &&
 					// or occupied by a statically mapped ISO
 					reflect.
 						ValueOf(&ideDisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", ideCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						IsNil() {
 					reflect.
 						ValueOf(&ideDisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", ideCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						Set(reflect.ValueOf(&dev))
-					ideCount++
+					diskIndex++
 					break
 				}
 				// if the disk field is not empty (occupied by an ISO), try the next index
-				log.Printf("ide%d occupied, trying next device index", ideCount)
-				ideCount++
+				log.Printf("ide%d occupied, trying next device index", diskIndex)
+				diskIndex++
 			}
 		case "scsi":
 			dev := proxmox.QemuScsiStorage{
@@ -491,24 +499,24 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 				},
 			}
 			for {
-				log.Printf("Mapping Disk to scsi%d", scsiCount)
-				if scsiCount > 30 {
-					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("storage enumeration reached scsi index %d, too many scsi devices configured. Ensure total disk and ISO scsi assignments don't exceed 31 devices", scsiCount))
+				log.Printf("Mapping Disk to scsi%d", diskIndex)
+				if diskIndex > 30 {
+					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("storage enumeration reached scsi index %d, too many scsi devices configured. Ensure total disk and ISO scsi assignments don't exceed 31 devices", diskIndex))
 					break
 				}
-				if !slices.Contains(cloneSourceDisks, fmt.Sprintf("scsi%d", scsiCount)) &&
+				if overwrite || !slices.Contains(cloneSourceDisks, fmt.Sprintf("scsi%d", diskIndex)) &&
 					reflect.ValueOf(&scsiDisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", scsiCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						IsNil() {
 					reflect.
 						ValueOf(&scsiDisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", scsiCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						Set(reflect.ValueOf(&dev))
-					scsiCount++
+					diskIndex++
 					break
 				}
-				log.Printf("scsi%d occupied, trying next device index", scsiCount)
-				scsiCount++
+				log.Printf("scsi%d occupied, trying next device index", diskIndex)
+				diskIndex++
 			}
 		case "sata":
 			dev := proxmox.QemuSataStorage{
@@ -524,24 +532,24 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 				},
 			}
 			for {
-				if sataCount > 5 {
-					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("storage enumeration reached sata index %d, too many sata devices configured. Ensure total disk and ISO sata assignments don't exceed 6 devices", sataCount))
+				if diskIndex > 5 {
+					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("storage enumeration reached sata index %d, too many sata devices configured. Ensure total disk and ISO sata assignments don't exceed 6 devices", diskIndex))
 					break
 				}
-				log.Printf("Mapping Disk to sata%d", sataCount)
-				if !slices.Contains(cloneSourceDisks, fmt.Sprintf("sata%d", sataCount)) &&
+				log.Printf("Mapping Disk to sata%d", diskIndex)
+				if overwrite || !slices.Contains(cloneSourceDisks, fmt.Sprintf("sata%d", diskIndex)) &&
 					reflect.ValueOf(&sataDisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", sataCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						IsNil() {
 					reflect.
 						ValueOf(&sataDisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", sataCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						Set(reflect.ValueOf(&dev))
-					sataCount++
+					diskIndex++
 					break
 				}
-				log.Printf("sata%d occupied, trying next device index", sataCount)
-				sataCount++
+				log.Printf("sata%d occupied, trying next device index", diskIndex)
+				diskIndex++
 			}
 		case "virtio":
 			dev := proxmox.QemuVirtIOStorage{
@@ -557,29 +565,32 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 				},
 			}
 			for {
-				log.Printf("Mapping Disk to virtio%d", virtIOCount)
-				if virtIOCount > 15 {
-					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("enumeration reached virtio index %d, too many virtio devices configured. Ensure total disk and ISO virtio assignments don't exceed 16 devices", virtIOCount))
+				log.Printf("Mapping Disk to virtio%d", diskIndex)
+				if diskIndex > 15 {
+					errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("enumeration reached virtio index %d, too many virtio devices configured. Ensure total disk and ISO virtio assignments don't exceed 16 devices", diskIndex))
 					break
 				}
-				if !slices.Contains(cloneSourceDisks, fmt.Sprintf("virtio%d", virtIOCount)) &&
+				if overwrite || !slices.Contains(cloneSourceDisks, fmt.Sprintf("virtio%d", diskIndex)) &&
 					reflect.ValueOf(&virtIODisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", virtIOCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						IsNil() {
 					reflect.
 						ValueOf(&virtIODisks).Elem().
-						FieldByName(fmt.Sprintf("Disk_%d", virtIOCount)).
+						FieldByName(fmt.Sprintf("Disk_%d", diskIndex)).
 						Set(reflect.ValueOf(&dev))
-					virtIOCount++
+					diskIndex++
 					break
 				}
-				log.Printf("virtio%d occupied, trying next device index", virtIOCount)
-				virtIOCount++
+				log.Printf("virtio%d occupied, trying next device index", diskIndex)
+				diskIndex++
 			}
 		}
 	}
 
 	// Map ISOs without static mappings in remaining device indexes
+	ideCount := 0
+	sataCount := 0
+	scsiCount := 0
 	if len(isos) > 0 {
 		for idx := range isos {
 			// if a static assignment has not been defined

--- a/docs-partials/builder/proxmox/common/diskConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/diskConfig-not-required.mdx
@@ -3,6 +3,9 @@
 - `type` (string) - The type of disk. Can be `scsi`, `sata`, `virtio` or
   `ide`. Defaults to `scsi`.
 
+- `index` (string) - Optional: Used to specify the index of a disk. Can be used in combination
+  with `type` and `size` to resize disks inherited from a cloned VM
+
 - `storage_pool` (string) - Required. Name of the Proxmox storage pool
   to store the virtual machine disk on. A `local-lvm` pool is allocated
   by the installer, for example.


### PR DESCRIPTION
### Description

Allows (but doesn't require) the user to explicitly set the index of a disk. If set, the plugin will update (not replace) any clone disks in the same slot. The upstream dependency `telmate/proxmox-api-go` intelligently resolves the configs and resizes the cloned disk (assuming the new size is greater than the current one). See the call to `Update` [here](https://github.com/hashicorp/packer-plugin-proxmox/blob/8d7f07ffa3e85d730a0726a17e38ddc9687fa211/builder/proxmox/clone/builder.go#L167) and the disk-resizing login in the function definition [here](https://github.com/Telmate/proxmox-api-go/blob/d954becd76b935f360ed9099017835a8ff03c465/proxmox/config_qemu.go#L550)

### Resolved Issues

Closes #309 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

NA

