### PR TITLE
Update `Telmate/proxmox-api-go`

### DIFF
--- a/builder/proxmox/clone/builder.go
+++ b/builder/proxmox/clone/builder.go
@@ -53,7 +53,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 type cloneVMCreator struct{}
 
-func (*cloneVMCreator) Create(vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQemu, state multistep.StateBag) error {
+func (*cloneVMCreator) Create(ctx context.Context, vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQemu, state multistep.StateBag) error {
 	client := state.Get("proxmoxClient").(*proxmoxapi.Client)
 	c := state.Get("clone-config").(*Config)
 	comm := state.Get("config").(*proxmox.Config).Comm
@@ -140,7 +140,7 @@ func (*cloneVMCreator) Create(vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQ
 
 	var sourceVmr *proxmoxapi.VmRef
 	if c.CloneVM != "" {
-		sourceVmrs, err := client.GetVmRefsByName(c.CloneVM)
+		sourceVmrs, err := client.GetVmRefsByName(ctx, c.CloneVM)
 		if err != nil {
 			return err
 		}
@@ -154,17 +154,17 @@ func (*cloneVMCreator) Create(vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQ
 		}
 	} else if c.CloneVMID != 0 {
 		sourceVmr = proxmoxapi.NewVmRef(c.CloneVMID)
-		err := client.CheckVmRef(sourceVmr)
+		err := client.CheckVmRef(ctx, sourceVmr)
 		if err != nil {
 			return err
 		}
 	}
 
-	err := config.CloneVm(sourceVmr, vmRef, client)
+	err := config.CloneVm(ctx, sourceVmr, vmRef, client)
 	if err != nil {
 		return err
 	}
-	_, err = config.Update(false, vmRef, client)
+	_, err = config.Update(ctx, false, vmRef, client)
 	if err != nil {
 		return err
 	}

--- a/builder/proxmox/clone/step_map_source_disks.go
+++ b/builder/proxmox/clone/step_map_source_disks.go
@@ -23,9 +23,9 @@ import (
 type StepMapSourceDisks struct{}
 
 type cloneSource interface {
-	GetVmConfig(*proxmoxapi.VmRef) (map[string]interface{}, error)
-	GetVmRefsByName(string) ([]*proxmoxapi.VmRef, error)
-	CheckVmRef(*proxmoxapi.VmRef) error
+	GetVmConfig(context.Context, *proxmoxapi.VmRef) (map[string]interface{}, error)
+	GetVmRefsByName(context.Context, string) ([]*proxmoxapi.VmRef, error)
+	CheckVmRef(context.Context, *proxmoxapi.VmRef) error
 }
 
 var _ cloneSource = &proxmoxapi.Client{}
@@ -37,7 +37,7 @@ func (s *StepMapSourceDisks) Run(ctx context.Context, state multistep.StateBag) 
 
 	var sourceVmr *proxmoxapi.VmRef
 	if c.CloneVM != "" {
-		sourceVmrs, err := client.GetVmRefsByName(c.CloneVM)
+		sourceVmrs, err := client.GetVmRefsByName(ctx, c.CloneVM)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Could not retrieve VM: %s", err))
 			return multistep.ActionHalt
@@ -51,14 +51,14 @@ func (s *StepMapSourceDisks) Run(ctx context.Context, state multistep.StateBag) 
 		}
 	} else if c.CloneVMID != 0 {
 		sourceVmr = proxmoxapi.NewVmRef(c.CloneVMID)
-		err := client.CheckVmRef(sourceVmr)
+		err := client.CheckVmRef(ctx, sourceVmr)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Could not retrieve VM: %s", err))
 			return multistep.ActionHalt
 		}
 	}
 
-	vmParams, err := client.GetVmConfig(sourceVmr)
+	vmParams, err := client.GetVmConfig(ctx, sourceVmr)
 	if err != nil {
 		err := fmt.Errorf("error fetching template config: %s", err)
 		state.Put("error", err)

--- a/builder/proxmox/common/artifact.go
+++ b/builder/proxmox/common/artifact.go
@@ -4,6 +4,7 @@
 package proxmox
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -47,6 +48,6 @@ func (a *Artifact) State(name string) interface{} {
 
 func (a *Artifact) Destroy() error {
 	log.Printf("Destroying template: %d", a.templateID)
-	_, err := a.proxmoxClient.DeleteVm(proxmox.NewVmRef(a.templateID))
+	_, err := a.proxmoxClient.DeleteVm(context.TODO(), proxmox.NewVmRef(a.templateID))
 	return err
 }

--- a/builder/proxmox/common/bootcommand_driver.go
+++ b/builder/proxmox/common/bootcommand_driver.go
@@ -4,6 +4,7 @@
 package proxmox
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -95,7 +96,7 @@ func (p *proxmoxDriver) SendKey(key rune, action bootcommand.KeyAction) error {
 	switch action.String() {
 	case "Press":
 		if special, ok := p.runeMap[key]; ok {
-			return p.send(special)
+			return p.send(context.TODO(), special)
 		}
 		var keys string
 		if unicode.IsUpper(key) {
@@ -103,7 +104,7 @@ func (p *proxmoxDriver) SendKey(key rune, action bootcommand.KeyAction) error {
 		} else {
 			keys = fmt.Sprintf("%c", key)
 		}
-		return p.send(keys)
+		return p.send(context.TODO(), keys)
 	case "On":
 		key := fmt.Sprintf("%c", key)
 		p.normalBuffer = addKeyToBuffer(p.normalBuffer, key)
@@ -121,7 +122,7 @@ func (p *proxmoxDriver) SendSpecial(special string, action bootcommand.KeyAction
 	}
 	switch action.String() {
 	case "Press":
-		return p.send(keys)
+		return p.send(context.TODO(), keys)
 	case "On":
 		p.specialBuffer = addKeyToBuffer(p.specialBuffer, keys)
 	case "Off":
@@ -130,11 +131,11 @@ func (p *proxmoxDriver) SendSpecial(special string, action bootcommand.KeyAction
 	return nil
 }
 
-func (p *proxmoxDriver) send(key string) error {
+func (p *proxmoxDriver) send(ctx context.Context, key string) error {
 	keys := append(p.specialBuffer, p.normalBuffer...)
 	keys = append(keys, key)
 	keyEventString := bufferToKeyEvent(keys)
-	err := p.client.Sendkey(p.vmRef, keyEventString)
+	err := p.client.Sendkey(ctx, p.vmRef, keyEventString)
 	if err != nil {
 		return err
 	}

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -37,7 +37,7 @@ type Builder struct {
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook, state multistep.StateBag) (packersdk.Artifact, error) {
 	var err error
-	b.proxmoxClient, err = newProxmoxClient(b.config)
+	b.proxmoxClient, err = newProxmoxClient(ctx, b.config)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func getVMIP(state multistep.StateBag) (string, error) {
 	config := state.Get("config").(*Config)
 	vmRef := state.Get("vmRef").(*proxmox.VmRef)
 
-	ifs, err := client.GetVmAgentNetworkInterfaces(vmRef)
+	ifs, err := client.GetVmAgentNetworkInterfaces(context.Background(), vmRef)
 	if err != nil {
 		return "", err
 	}

--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -4,6 +4,7 @@
 package proxmox
 
 import (
+	"context"
 	"crypto/tls"
 	"log"
 	"strings"
@@ -11,7 +12,7 @@ import (
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
-func newProxmoxClient(config Config) (*proxmox.Client, error) {
+func newProxmoxClient(ctx context.Context, config Config) (*proxmox.Client, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: config.SkipCertValidation,
 	}
@@ -30,7 +31,7 @@ func newProxmoxClient(config Config) (*proxmox.Client, error) {
 	} else {
 		// fallback to login if not using tokens
 		log.Print("using password auth")
-		err = client.Login(config.Username, config.Password, "")
+		err = client.Login(ctx, config.Username, config.Password, "")
 		if err != nil {
 			return nil, err
 		}

--- a/builder/proxmox/common/client_test.go
+++ b/builder/proxmox/common/client_test.go
@@ -4,6 +4,7 @@
 package proxmox
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -33,13 +34,13 @@ func TestTokenAuth(t *testing.T) {
 		Token:              "ac5293bf-15e2-477f-b04c-a6dfa7a46b80",
 	}
 
-	client, err := newProxmoxClient(config)
+	client, err := newProxmoxClient(context.TODO(), config)
 	require.NoError(t, err)
 
 	ref := proxmox.NewVmRef(110)
 	ref.SetNode("node1")
 	ref.SetVmType("qemu")
-	err = client.Sendkey(ref, "ping")
+	err = client.Sendkey(context.TODO(), ref, "ping")
 	require.NoError(t, err)
 }
 
@@ -83,12 +84,12 @@ func TestLogin(t *testing.T) {
 		Token:              "",
 	}
 
-	client, err := newProxmoxClient(config)
+	client, err := newProxmoxClient(context.TODO(), config)
 	require.NoError(t, err)
 
 	ref := proxmox.NewVmRef(110)
 	ref.SetNode("node1")
 	ref.SetVmType("qemu")
-	err = client.Sendkey(ref, "ping")
+	err = client.Sendkey(context.TODO(), ref, "ping")
 	require.NoError(t, err)
 }

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -557,16 +557,19 @@ type pciDeviceConfig struct {
 	Host string `mapstructure:"host"`
 	// Override PCI device ID visible to guest.
 	DeviceID string `mapstructure:"device_id"`
+	// FIXME: not supported upstream
 	// Pass this device in legacy IGD mode, making it the primary and exclusive graphics device in the VM. Requires `pc-i440fx` machine type and VGA set to `none`. Defaults to `false`.
 	LegacyIGD bool `mapstructure:"legacy_igd"`
 	// The ID of a cluster wide mapping. Either this or the `host` key must be set.
 	Mapping string `mapstructure:"mapping"`
 	// Present the device as a PCIe device (needs `q35` machine model). Defaults to `false`.
 	PCIe bool `mapstructure:"pcie"`
+	// FIXME: not supported upstream
 	// The type of mediated device to use. An instance of this type will be created on startup of the VM and will be cleaned up when the VM stops.
 	MDEV string `mapstructure:"mdev"`
 	// Specify whether or not the device’s ROM BAR will be visible in the guest’s memory map. Defaults to `false`.
 	HideROMBAR bool `mapstructure:"hide_rombar"`
+	// FIXME: not supported upstream
 	// Custom PCI device rom filename (must be located in `/usr/share/kvm/`).
 	ROMFile string `mapstructure:"romfile"`
 	//Override PCI subsystem device ID visible to guest.

--- a/builder/proxmox/common/step_convert_to_template.go
+++ b/builder/proxmox/common/step_convert_to_template.go
@@ -20,8 +20,8 @@ import (
 type stepConvertToTemplate struct{}
 
 type templateConverter interface {
-	ShutdownVm(*proxmox.VmRef) (string, error)
-	CreateTemplate(*proxmox.VmRef) error
+	ShutdownVm(context.Context, *proxmox.VmRef) (string, error)
+	CreateTemplate(context.Context, *proxmox.VmRef) error
 }
 
 var _ templateConverter = &proxmox.Client{}
@@ -32,7 +32,7 @@ func (s *stepConvertToTemplate) Run(ctx context.Context, state multistep.StateBa
 	vmRef := state.Get("vmRef").(*proxmox.VmRef)
 
 	ui.Say("Stopping VM")
-	_, err := client.ShutdownVm(vmRef)
+	_, err := client.ShutdownVm(ctx, vmRef)
 	if err != nil {
 		err := fmt.Errorf("Error converting VM to template, could not stop: %s", err)
 		state.Put("error", err)
@@ -41,7 +41,7 @@ func (s *stepConvertToTemplate) Run(ctx context.Context, state multistep.StateBa
 	}
 
 	ui.Say("Converting VM to template")
-	err = client.CreateTemplate(vmRef)
+	err = client.CreateTemplate(ctx, vmRef)
 	if err != nil {
 		err := fmt.Errorf("Error converting VM to template: %s", err)
 		state.Put("error", err)

--- a/builder/proxmox/common/step_convert_to_template_test.go
+++ b/builder/proxmox/common/step_convert_to_template_test.go
@@ -14,15 +14,15 @@ import (
 )
 
 type converterMock struct {
-	shutdownVm     func(*proxmox.VmRef) (string, error)
-	createTemplate func(*proxmox.VmRef) error
+	shutdownVm     func(context.Context, *proxmox.VmRef) (string, error)
+	createTemplate func(context.Context, *proxmox.VmRef) error
 }
 
-func (m converterMock) ShutdownVm(r *proxmox.VmRef) (string, error) {
-	return m.shutdownVm(r)
+func (m converterMock) ShutdownVm(ctx context.Context, r *proxmox.VmRef) (string, error) {
+	return m.shutdownVm(ctx, r)
 }
-func (m converterMock) CreateTemplate(r *proxmox.VmRef) error {
-	return m.createTemplate(r)
+func (m converterMock) CreateTemplate(ctx context.Context, r *proxmox.VmRef) error {
+	return m.createTemplate(ctx, r)
 }
 
 var _ templateConverter = converterMock{}
@@ -63,13 +63,13 @@ func TestConvertToTemplate(t *testing.T) {
 	for _, c := range cs {
 		t.Run(c.name, func(t *testing.T) {
 			converter := converterMock{
-				shutdownVm: func(r *proxmox.VmRef) (string, error) {
+				shutdownVm: func(ctx context.Context, r *proxmox.VmRef) (string, error) {
 					if r.VmId() != vmid {
 						t.Errorf("ShutdownVm called with unexpected id, expected %d, got %d", vmid, r.VmId())
 					}
 					return "", c.shutdownErr
 				},
-				createTemplate: func(r *proxmox.VmRef) error {
+				createTemplate: func(ctx context.Context, r *proxmox.VmRef) error {
 					if r.VmId() != vmid {
 						t.Errorf("CreateTemplate called with unexpected id, expected %d, got %d", vmid, r.VmId())
 					}

--- a/builder/proxmox/common/step_download_iso_on_pve.go
+++ b/builder/proxmox/common/step_download_iso_on_pve.go
@@ -25,7 +25,7 @@ type stepDownloadISOOnPVE struct {
 
 func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	var isoStoragePath string
-	isoStoragePath, err := DownloadISOOnPVE(state, s.ISO.ISOUrls, s.ISO.ISOChecksum, s.ISO.ISOStoragePool)
+	isoStoragePath, err := DownloadISOOnPVE(ctx, state, s.ISO.ISOUrls, s.ISO.ISOChecksum, s.ISO.ISOStoragePool)
 
 	// Abort if no ISO can be downloaded
 	if err != nil {
@@ -44,7 +44,7 @@ func (s *stepDownloadISOOnPVE) Run(ctx context.Context, state multistep.StateBag
 // If a download was successful it skips the additonal downlaod mirrors and returns the path to the iso on the node.
 //
 // Returns: When successful, the path to the iso on the node, else an empty string.
-func DownloadISOOnPVE(state multistep.StateBag, ISOUrls []string, ISOChecksum string, ISOStoragePool string) (string, error) {
+func DownloadISOOnPVE(ctx context.Context, state multistep.StateBag, ISOUrls []string, ISOChecksum string, ISOStoragePool string) (string, error) {
 	ui := state.Get("ui").(packersdk.Ui)
 	client := state.Get("proxmoxClient").(*proxmox.Client)
 	c := state.Get("config").(*Config)
@@ -80,7 +80,7 @@ func DownloadISOOnPVE(state multistep.StateBag, ISOUrls []string, ISOChecksum st
 		}
 
 		log.Printf("[INFO] - beginning download of %s to node %s", isoConfig.DownloadUrl, isoConfig.Node)
-		err := proxmox.DownloadIsoFromUrl(client, isoConfig)
+		err := proxmox.DownloadIsoFromUrl(ctx, client, isoConfig)
 		// On error continues with the next URL and logs the error
 		if err != nil {
 			log.Printf("[ERROR] - failed to download iso from %s: %s", isoConfig.DownloadUrl, err)

--- a/builder/proxmox/common/step_finalize_template_config.go
+++ b/builder/proxmox/common/step_finalize_template_config.go
@@ -20,7 +20,7 @@ import (
 type stepFinalizeTemplateConfig struct{}
 
 type templateFinalizer interface {
-	GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error)
+	GetVmConfig(context.Context, *proxmox.VmRef) (map[string]interface{}, error)
 	SetVmConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error)
 }
 
@@ -43,7 +43,7 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 	// set, we need to clear it
 	changes["description"] = c.TemplateDescription
 
-	vmParams, err := client.GetVmConfig(vmRef)
+	vmParams, err := client.GetVmConfig(ctx, vmRef)
 	if err != nil {
 		err := fmt.Errorf("error fetching template config: %s", err)
 		state.Put("error", err)

--- a/builder/proxmox/common/step_finalize_template_config_test.go
+++ b/builder/proxmox/common/step_finalize_template_config_test.go
@@ -20,7 +20,7 @@ type finalizerMock struct {
 	setConfig func(map[string]interface{}) (string, error)
 }
 
-func (m finalizerMock) GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error) {
+func (m finalizerMock) GetVmConfig(context.Context, *proxmox.VmRef) (map[string]interface{}, error) {
 	return m.getConfig()
 }
 func (m finalizerMock) SetVmConfig(vmref *proxmox.VmRef, c map[string]interface{}) (interface{}, error) {

--- a/builder/proxmox/common/step_remove_cloud_init_drive.go
+++ b/builder/proxmox/common/step_remove_cloud_init_drive.go
@@ -18,7 +18,7 @@ import (
 type stepRemoveCloudInitDrive struct{}
 
 type CloudInitDriveRemover interface {
-	GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error)
+	GetVmConfig(context.Context, *proxmox.VmRef) (map[string]interface{}, error)
 	SetVmConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error)
 }
 
@@ -32,7 +32,7 @@ func (s *stepRemoveCloudInitDrive) Run(ctx context.Context, state multistep.Stat
 	changes := make(map[string]interface{})
 	delete := []string{}
 
-	vmParams, err := client.GetVmConfig(vmRef)
+	vmParams, err := client.GetVmConfig(ctx, vmRef)
 	if err != nil {
 		err := fmt.Errorf("error fetching template config: %s", err)
 		state.Put("error", err)

--- a/builder/proxmox/common/step_remove_cloud_init_drive_test.go
+++ b/builder/proxmox/common/step_remove_cloud_init_drive_test.go
@@ -17,7 +17,7 @@ type CloudInitDriveRemoverMock struct {
 	setConfig func(map[string]interface{}) (string, error)
 }
 
-func (m CloudInitDriveRemoverMock) GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error) {
+func (m CloudInitDriveRemoverMock) GetVmConfig(context.Context, *proxmox.VmRef) (map[string]interface{}, error) {
 	return m.getConfig()
 }
 func (m CloudInitDriveRemoverMock) SetVmConfig(vmref *proxmox.VmRef, c map[string]interface{}) (interface{}, error) {

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -138,21 +138,21 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Memory: &proxmox.QemuMemory{
 			CapacityMiB: (*proxmox.QemuMemoryCapacity)(&c.Memory),
 		},
-		QemuOs:         c.OS,
-		Bios:           c.BIOS,
-		EFIDisk:        generateProxmoxEfi(c.EFIConfig),
-		Machine:        c.Machine,
-		RNGDrive:       generateProxmoxRng0(c.Rng0),
-		TPM:            generateProxmoxTpm(c.TPMConfig),
-		QemuVga:        generateProxmoxVga(c.VGA),
-		Networks:       generateProxmoxNetworkAdapters(c.NICs),
-		Disks:          disks,
-		QemuPCIDevices: generateProxmoxPCIDeviceMap(c.PCIDevices),
-		Serials:        generateProxmoxSerials(c.Serials),
-		Scsihw:         c.SCSIController,
-		Onboot:         &c.Onboot,
-		Args:           c.AdditionalArgs,
-		Pool:           (*proxmox.PoolName)(&c.Pool),
+		QemuOs:     c.OS,
+		Bios:       c.BIOS,
+		EFIDisk:    generateProxmoxEfi(c.EFIConfig),
+		Machine:    c.Machine,
+		RNGDrive:   generateProxmoxRng0(c.Rng0),
+		TPM:        generateProxmoxTpm(c.TPMConfig),
+		QemuVga:    generateProxmoxVga(c.VGA),
+		Networks:   generateProxmoxNetworkAdapters(c.NICs),
+		Disks:      disks,
+		PciDevices: generateProxmoxPCIDeviceMap(c.PCIDevices),
+		Serials:    generateProxmoxSerials(c.Serials),
+		Scsihw:     c.SCSIController,
+		Onboot:     &c.Onboot,
+		Args:       c.AdditionalArgs,
+		Pool:       (*proxmox.PoolName)(&c.Pool),
 	}
 
 	// 0 disables the ballooning device, which is useful for all VMs
@@ -701,23 +701,61 @@ func generateProxmoxDisks(disks []diskConfig, isos []ISOsConfig, cloneSourceDisk
 	return errs, warnings, &qemuStorages
 }
 
-func generateProxmoxPCIDeviceMap(devices []pciDeviceConfig) proxmox.QemuDevices {
-	devs := make(proxmox.QemuDevices)
-	for idx := range devices {
-		devs[idx] = make(proxmox.QemuDevice)
-		setDeviceParamIfDefined(devs[idx], "host", devices[idx].Host)
-		setDeviceParamIfDefined(devs[idx], "device-id", devices[idx].DeviceID)
-		setDeviceParamIfDefined(devs[idx], "mapping", devices[idx].Mapping)
-		setDeviceParamIfDefined(devs[idx], "mdev", devices[idx].MDEV)
-		setDeviceParamIfDefined(devs[idx], "romfile", devices[idx].ROMFile)
-		setDeviceParamIfDefined(devs[idx], "sub-device-id", devices[idx].SubDeviceID)
-		setDeviceParamIfDefined(devs[idx], "sub-vendor-id", devices[idx].SubVendorID)
-		setDeviceParamIfDefined(devs[idx], "vendor-id", devices[idx].VendorID)
+func generateProxmoxPCIDeviceMap(devices []pciDeviceConfig) proxmox.QemuPciDevices {
+	devs := make(proxmox.QemuPciDevices, len(devices))
+	for i := range devices {
+		var deviceID *proxmox.PciDeviceID
+		if v := devices[i].DeviceID; v != "" {
+			deviceID = (*proxmox.PciDeviceID)(&v)
+		}
+		var subDeviceID *proxmox.PciSubDeviceID
+		if v := devices[i].SubDeviceID; v != "" {
+			subDeviceID = (*proxmox.PciSubDeviceID)(&v)
+		}
+		var vendorID *proxmox.PciVendorID
+		if v := devices[i].VendorID; v != "" {
+			vendorID = (*proxmox.PciVendorID)(&v)
+		}
+		var subVendorID *proxmox.PciSubVendorID
+		if v := devices[i].SubVendorID; v != "" {
+			subVendorID = (*proxmox.PciSubVendorID)(&v)
+		}
+		romBar := !devices[i].HideROMBAR
+		primaryGPU := devices[i].XVGA
+		pCIE := devices[i].PCIe
 
-		devs[idx]["pcie"] = strconv.FormatBool(devices[idx].PCIe)
-		devs[idx]["rombar"] = strconv.FormatBool(!devices[idx].HideROMBAR)
-		devs[idx]["x-vga"] = strconv.FormatBool(devices[idx].XVGA)
-		devs[idx]["legacy-igd"] = strconv.FormatBool(devices[idx].LegacyIGD)
+		if v := devices[i].Host; v != "" {
+			vv := proxmox.PciID(v)
+			devs[proxmox.QemuPciID(i)] = proxmox.QemuPci{
+				Raw: &proxmox.QemuPciRaw{
+					DeviceID:    deviceID,
+					ID:          &vv,
+					PCIe:        &pCIE,
+					PrimaryGPU:  &primaryGPU,
+					ROMbar:      &romBar,
+					SubDeviceID: subDeviceID,
+					SubVendorID: subVendorID,
+					VendorID:    vendorID}}
+			continue
+		}
+		if v := devices[i].Mapping; v != "" {
+			vv := proxmox.ResourceMappingPciID(v)
+			devs[proxmox.QemuPciID(i)] = proxmox.QemuPci{
+				Mapping: &proxmox.QemuPciMapping{
+					DeviceID:    deviceID,
+					ID:          &vv,
+					PCIe:        &pCIE,
+					PrimaryGPU:  &primaryGPU,
+					ROMbar:      &romBar,
+					SubDeviceID: subDeviceID,
+					SubVendorID: subVendorID,
+					VendorID:    vendorID}}
+			continue
+		}
+		// TODO implement upstream
+		// setDeviceParamIfDefined(devs[i], "mdev", devices[i].MDEV)
+		// setDeviceParamIfDefined(devs[i], "romfile", devices[i].ROMFile)
+		// devs[i]["legacy-igd"] = strconv.FormatBool(devices[i].LegacyIGD)
 	}
 	return devs
 }

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -27,16 +27,16 @@ type stepStartVM struct {
 }
 
 type ProxmoxVMCreator interface {
-	Create(*proxmox.VmRef, proxmox.ConfigQemu, multistep.StateBag) error
+	Create(context.Context, *proxmox.VmRef, proxmox.ConfigQemu, multistep.StateBag) error
 }
 type vmStarter interface {
-	CheckVmRef(vmr *proxmox.VmRef) (err error)
-	DeleteVm(vmr *proxmox.VmRef) (exitStatus string, err error)
-	GetNextID(int) (int, error)
-	GetVmConfig(vmr *proxmox.VmRef) (vmConfig map[string]interface{}, err error)
-	GetVmRefsByName(vmName string) (vmrs []*proxmox.VmRef, err error)
-	SetVmConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error)
-	StartVm(*proxmox.VmRef) (string, error)
+	CheckVmRef(ctx context.Context, vmr *proxmox.VmRef) (err error)
+	DeleteVm(ctx context.Context, vmr *proxmox.VmRef) (exitStatus string, err error)
+	GetNextID(context.Context, int) (int, error)
+	GetVmConfig(ctx context.Context, vmr *proxmox.VmRef) (vmConfig map[string]interface{}, err error)
+	GetVmRefsByName(ctx context.Context, vmName string) (vmrs []*proxmox.VmRef, err error)
+	SetVmConfig(context.Context, *proxmox.VmRef, map[string]interface{}) (interface{}, error)
+	StartVm(context.Context, *proxmox.VmRef) (string, error)
 }
 
 var (
@@ -45,12 +45,12 @@ var (
 
 // Check if the given builder configuration maps to an existing VM template on the Proxmox cluster.
 // Returns an empty *proxmox.VmRef when no matching ID or name is found.
-func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
+func getExistingTemplate(ctx context.Context, c *Config, client vmStarter) (*proxmox.VmRef, error) {
 	vmRef := &proxmox.VmRef{}
 	if c.VMID > 0 {
 		log.Printf("looking up VM with ID %d", c.VMID)
 		vmRef = proxmox.NewVmRef(c.VMID)
-		err := client.CheckVmRef(vmRef)
+		err := client.CheckVmRef(ctx, vmRef)
 		if err != nil {
 			// expect an error if no VM is found
 			// the error string is defined in GetVmInfo() of proxmox-api-go
@@ -64,7 +64,7 @@ func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
 		log.Printf("found VM with ID %d", vmRef.VmId())
 	} else {
 		log.Printf("looking up VMs with name '%s'", c.TemplateName)
-		vmRefs, err := client.GetVmRefsByName(c.TemplateName)
+		vmRefs, err := client.GetVmRefsByName(ctx, c.TemplateName)
 		if err != nil {
 			// expect an error if no VMs are found
 			// the error string is defined in GetVmRefsByName() of proxmox-api-go
@@ -86,7 +86,7 @@ func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
 		log.Printf("found VM with name '%s' (ID: %d)", c.TemplateName, vmRef.VmId())
 	}
 	log.Printf("check if VM %d is a template", vmRef.VmId())
-	vmConfig, err := client.GetVmConfig(vmRef)
+	vmConfig, err := client.GetVmConfig(ctx, vmRef)
 	if err != nil {
 		return &proxmox.VmRef{}, err
 	}
@@ -163,7 +163,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 
 	if c.PackerForce {
 		ui.Say("Force set, checking for existing artifact on PVE cluster")
-		vmRef, err := getExistingTemplate(c, client)
+		vmRef, err := getExistingTemplate(ctx, c, client)
 		if err != nil {
 			state.Put("error", err)
 			ui.Error(err.Error())
@@ -171,7 +171,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		}
 		if vmRef.VmId() != 0 {
 			ui.Say(fmt.Sprintf("found existing VM template with ID %d on PVE node %s, deleting it", vmRef.VmId(), vmRef.Node()))
-			_, err = client.DeleteVm(vmRef)
+			_, err = client.DeleteVm(ctx, vmRef)
 			if err != nil {
 				state.Put("error", err)
 				ui.Error(fmt.Sprintf("error deleting VM template: %s", err.Error()))
@@ -189,7 +189,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		id := c.VMID
 		if id == 0 {
 			ui.Say("No VM ID given, getting next free from Proxmox")
-			genID, err := client.GetNextID(0)
+			genID, err := client.GetNextID(ctx, 0)
 			if err != nil {
 				state.Put("error", err)
 				ui.Error(err.Error())
@@ -204,7 +204,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 			vmRef.SetPool(c.Pool)
 		}
 
-		err := s.vmCreator.Create(vmRef, config, state)
+		err := s.vmCreator.Create(ctx, vmRef, config, state)
 		if err == nil {
 			break
 		}
@@ -227,7 +227,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 	if c.EFIConfig != (efiConfig{}) && c.Ctx.BuildType == "proxmox-clone" {
 		addEFIConfig := make(map[string]interface{})
 		config.CreateQemuEfiParams(addEFIConfig)
-		_, err := client.SetVmConfig(vmRef, addEFIConfig)
+		_, err := client.SetVmConfig(ctx, vmRef, addEFIConfig)
 		if err != nil {
 			err := fmt.Errorf("error updating template: %s", err)
 			state.Put("error", err)
@@ -245,7 +245,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 	state.Put("instance_id", vmRef.VmId())
 
 	ui.Say("Starting VM")
-	_, err := client.StartVm(vmRef)
+	_, err := client.StartVm(ctx, vmRef)
 	if err != nil {
 		err := fmt.Errorf("Error starting VM: %s", err)
 		state.Put("error", err)
@@ -783,8 +783,8 @@ func isDuplicateIDError(err error) bool {
 }
 
 type startedVMCleaner interface {
-	StopVm(*proxmox.VmRef) (string, error)
-	DeleteVm(*proxmox.VmRef) (string, error)
+	StopVm(context.Context, *proxmox.VmRef) (string, error)
+	DeleteVm(context.Context, *proxmox.VmRef) (string, error)
 }
 
 var _ startedVMCleaner = &proxmox.Client{}
@@ -808,14 +808,14 @@ func (s *stepStartVM) Cleanup(state multistep.StateBag) {
 
 	// Destroy the server we just created
 	ui.Say("Stopping VM")
-	_, err := client.StopVm(vmRef)
+	_, err := client.StopVm(context.Background(), vmRef)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Error stopping VM. Please stop and delete it manually: %s", err))
 		return
 	}
 
 	ui.Say("Deleting VM")
-	_, err = client.DeleteVm(vmRef)
+	_, err = client.DeleteVm(context.Background(), vmRef)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Error deleting VM. Please delete it manually: %s", err))
 		return

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"reflect"
 	"slices"
 	"strconv"
@@ -144,7 +145,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		RNGDrive:       generateProxmoxRng0(c.Rng0),
 		TPM:            generateProxmoxTpm(c.TPMConfig),
 		QemuVga:        generateProxmoxVga(c.VGA),
-		QemuNetworks:   generateProxmoxNetworkAdapters(c.NICs),
+		Networks:       generateProxmoxNetworkAdapters(c.NICs),
 		Disks:          disks,
 		QemuPCIDevices: generateProxmoxPCIDeviceMap(c.PCIDevices),
 		Serials:        generateProxmoxSerials(c.Serials),
@@ -280,25 +281,45 @@ func generateTags(rawTags string) *[]proxmox.Tag {
 	return &tags
 }
 
-func generateProxmoxNetworkAdapters(nics []NICConfig) proxmox.QemuDevices {
-	devs := make(proxmox.QemuDevices)
-	for idx := range nics {
-		devs[idx] = make(proxmox.QemuDevice)
-		setDeviceParamIfDefined(devs[idx], "model", nics[idx].Model)
-		setDeviceParamIfDefined(devs[idx], "macaddr", nics[idx].MACAddress)
-		setDeviceParamIfDefined(devs[idx], "bridge", nics[idx].Bridge)
-		setDeviceParamIfDefined(devs[idx], "tag", nics[idx].VLANTag)
-
-		if nics[idx].Firewall {
-			devs[idx]["firewall"] = nics[idx].Firewall
+func generateProxmoxNetworkAdapters(nics []NICConfig) proxmox.QemuNetworkInterfaces {
+	devs := make(proxmox.QemuNetworkInterfaces, len(nics))
+	for i := range nics {
+		var dev proxmox.QemuNetworkInterface
+		if v := proxmox.QemuNetworkModel(nics[i].Model); v != "" {
+			dev.Model = &v
 		}
-
-		if nics[idx].MTU > 0 {
-			devs[idx]["mtu"] = nics[idx].MTU
+		if v := nics[i].MACAddress; v != "" {
+			if vv, err := net.ParseMAC(v); err == nil {
+				dev.MAC = &vv
+			}
 		}
-		if nics[idx].PacketQueues > 0 {
-			devs[idx]["queues"] = nics[idx].PacketQueues
+		if v := nics[i].Bridge; v != "" {
+			dev.Bridge = &v
 		}
+		if v := nics[i].VLANTag; v != "" {
+			if vv, err := strconv.Atoi(v); err == nil {
+				vvv := proxmox.Vlan(vv)
+				dev.NativeVlan = &vvv
+			}
+		}
+		if v := nics[i].Firewall; v {
+			dev.Firewall = &v
+		}
+		if v := nics[i].MTU; v > 0 {
+			var mtu proxmox.QemuMTU
+			const mtuInherit = 1
+			if v == mtuInherit {
+				mtu.Inherit = true
+			} else {
+				mtu.Value = proxmox.MTU(v)
+			}
+			dev.MTU = &mtu
+		}
+		if v := nics[i].PacketQueues; v > 0 {
+			vv := proxmox.QemuNetworkQueue(v)
+			dev.MultiQueue = &vv
+		}
+		devs[proxmox.QemuNetworkInterfaceID(i)] = dev
 	}
 	return devs
 }

--- a/builder/proxmox/common/step_start_vm_test.go
+++ b/builder/proxmox/common/step_start_vm_test.go
@@ -20,10 +20,10 @@ type startedVMCleanerMock struct {
 	deleteVm func() (string, error)
 }
 
-func (m startedVMCleanerMock) StopVm(*proxmox.VmRef) (string, error) {
+func (m startedVMCleanerMock) StopVm(context.Context, *proxmox.VmRef) (string, error) {
 	return m.stopVm()
 }
-func (m startedVMCleanerMock) DeleteVm(*proxmox.VmRef) (string, error) {
+func (m startedVMCleanerMock) DeleteVm(context.Context, *proxmox.VmRef) (string, error) {
 	return m.deleteVm()
 }
 
@@ -114,39 +114,39 @@ func TestCleanupStartVM(t *testing.T) {
 }
 
 type startVMMock struct {
-	create      func(*proxmox.VmRef, proxmox.ConfigQemu, multistep.StateBag) error
-	startVm     func(*proxmox.VmRef) (string, error)
-	setVmConfig func(*proxmox.VmRef, map[string]interface{}) (interface{}, error)
-	getNextID   func(id int) (int, error)
-	getVmConfig func(vmr *proxmox.VmRef) (vmConfig map[string]interface{}, err error)
-	checkVmRef  func(vmr *proxmox.VmRef) (err error)
-	getVmByName func(vmName string) (vmrs []*proxmox.VmRef, err error)
-	deleteVm    func(vmr *proxmox.VmRef) (exitStatus string, err error)
+	create      func(context.Context, *proxmox.VmRef, proxmox.ConfigQemu, multistep.StateBag) error
+	startVm     func(context.Context, *proxmox.VmRef) (string, error)
+	setVmConfig func(context.Context, *proxmox.VmRef, map[string]interface{}) (interface{}, error)
+	getNextID   func(ctx context.Context, id int) (int, error)
+	getVmConfig func(ctx context.Context, vmr *proxmox.VmRef) (vmConfig map[string]interface{}, err error)
+	checkVmRef  func(ctx context.Context, vmr *proxmox.VmRef) (err error)
+	getVmByName func(ctx context.Context, vmName string) (vmrs []*proxmox.VmRef, err error)
+	deleteVm    func(ctx context.Context, vmr *proxmox.VmRef) (exitStatus string, err error)
 }
 
-func (m *startVMMock) Create(vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
-	return m.create(vmRef, config, state)
+func (m *startVMMock) Create(ctx context.Context, vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
+	return m.create(ctx, vmRef, config, state)
 }
-func (m *startVMMock) StartVm(vmRef *proxmox.VmRef) (string, error) {
-	return m.startVm(vmRef)
+func (m *startVMMock) StartVm(ctx context.Context, vmRef *proxmox.VmRef) (string, error) {
+	return m.startVm(ctx, vmRef)
 }
-func (m *startVMMock) SetVmConfig(vmRef *proxmox.VmRef, config map[string]interface{}) (interface{}, error) {
-	return m.setVmConfig(vmRef, config)
+func (m *startVMMock) SetVmConfig(ctx context.Context, vmRef *proxmox.VmRef, config map[string]interface{}) (interface{}, error) {
+	return m.setVmConfig(ctx, vmRef, config)
 }
-func (m *startVMMock) GetNextID(id int) (int, error) {
-	return m.getNextID(id)
+func (m *startVMMock) GetNextID(ctx context.Context, id int) (int, error) {
+	return m.getNextID(ctx, id)
 }
-func (m *startVMMock) GetVmConfig(vmr *proxmox.VmRef) (map[string]interface{}, error) {
-	return m.getVmConfig(vmr)
+func (m *startVMMock) GetVmConfig(ctx context.Context, vmr *proxmox.VmRef) (map[string]interface{}, error) {
+	return m.getVmConfig(ctx, vmr)
 }
-func (m *startVMMock) CheckVmRef(vmr *proxmox.VmRef) (err error) {
-	return m.checkVmRef(vmr)
+func (m *startVMMock) CheckVmRef(ctx context.Context, vmr *proxmox.VmRef) (err error) {
+	return m.checkVmRef(ctx, vmr)
 }
-func (m *startVMMock) GetVmRefsByName(vmName string) (vmrs []*proxmox.VmRef, err error) {
-	return m.getVmByName(vmName)
+func (m *startVMMock) GetVmRefsByName(ctx context.Context, vmName string) (vmrs []*proxmox.VmRef, err error) {
+	return m.getVmByName(ctx, vmName)
 }
-func (m *startVMMock) DeleteVm(vmr *proxmox.VmRef) (exitStatus string, err error) {
-	return m.deleteVm(vmr)
+func (m *startVMMock) DeleteVm(ctx context.Context, vmr *proxmox.VmRef) (exitStatus string, err error) {
+	return m.deleteVm(ctx, vmr)
 }
 
 func TestStartVM(t *testing.T) {
@@ -183,16 +183,16 @@ func TestStartVM(t *testing.T) {
 	for _, c := range cs {
 		t.Run(c.name, func(t *testing.T) {
 			mock := &startVMMock{
-				create: func(vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
+				create: func(ctx context.Context, vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
 					return nil
 				},
-				startVm: func(*proxmox.VmRef) (string, error) {
+				startVm: func(context.Context, *proxmox.VmRef) (string, error) {
 					return "", nil
 				},
-				setVmConfig: func(*proxmox.VmRef, map[string]interface{}) (interface{}, error) {
+				setVmConfig: func(context.Context, *proxmox.VmRef, map[string]interface{}) (interface{}, error) {
 					return nil, nil
 				},
-				getNextID: func(id int) (int, error) {
+				getNextID: func(ctx context.Context, id int) (int, error) {
 					return 1, nil
 				},
 			}
@@ -269,17 +269,17 @@ func TestStartVMRetryOnDuplicateID(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			createCalls := 0
 			mock := &startVMMock{
-				create: func(vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
+				create: func(ctx context.Context, vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
 					createCalls++
 					return c.createErrorGenerator(vmRef.VmId())
 				},
-				startVm: func(*proxmox.VmRef) (string, error) {
+				startVm: func(context.Context, *proxmox.VmRef) (string, error) {
 					return "", nil
 				},
-				setVmConfig: func(*proxmox.VmRef, map[string]interface{}) (interface{}, error) {
+				setVmConfig: func(context.Context, *proxmox.VmRef, map[string]interface{}) (interface{}, error) {
 					return nil, nil
 				},
-				getNextID: func(id int) (int, error) {
+				getNextID: func(ctx context.Context, id int) (int, error) {
 					return createCalls + 1, nil
 				},
 			}
@@ -397,28 +397,28 @@ func TestStartVMWithForce(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			deleteWasCalled := false
 			mock := &startVMMock{
-				create: func(vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
+				create: func(ctx context.Context, vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
 					return nil
 				},
-				startVm: func(*proxmox.VmRef) (string, error) {
+				startVm: func(context.Context, *proxmox.VmRef) (string, error) {
 					return "", nil
 				},
-				setVmConfig: func(*proxmox.VmRef, map[string]interface{}) (interface{}, error) {
+				setVmConfig: func(context.Context, *proxmox.VmRef, map[string]interface{}) (interface{}, error) {
 					return nil, nil
 				},
-				getNextID: func(id int) (int, error) {
+				getNextID: func(ctx context.Context, id int) (int, error) {
 					return 101, nil
 				},
-				checkVmRef: func(vmr *proxmox.VmRef) (err error) {
+				checkVmRef: func(ctx context.Context, vmr *proxmox.VmRef) (err error) {
 					return nil
 				},
-				getVmByName: func(vmName string) (vmrs []*proxmox.VmRef, err error) {
+				getVmByName: func(ctx context.Context, vmName string) (vmrs []*proxmox.VmRef, err error) {
 					return c.mockGetVmRefsByName(vmName)
 				},
-				getVmConfig: func(vmr *proxmox.VmRef) (config map[string]interface{}, err error) {
+				getVmConfig: func(ctx context.Context, vmr *proxmox.VmRef) (config map[string]interface{}, err error) {
 					return c.mockGetVmConfig(vmr)
 				},
-				deleteVm: func(vmr *proxmox.VmRef) (exitStatus string, err error) {
+				deleteVm: func(ctx context.Context, vmr *proxmox.VmRef) (exitStatus string, err error) {
 					deleteWasCalled = true
 					return "", nil
 				},
@@ -469,15 +469,15 @@ func TestStartVM_AssertInitialQuemuConfig(t *testing.T) {
 			startVMWasCalled := false
 			qemuConfig := proxmox.ConfigQemu{}
 			mock := &startVMMock{
-				create: func(vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
+				create: func(ctx context.Context, vmRef *proxmox.VmRef, config proxmox.ConfigQemu, state multistep.StateBag) error {
 					qemuConfig = config
 					return nil
 				},
-				startVm: func(*proxmox.VmRef) (string, error) {
+				startVm: func(context.Context, *proxmox.VmRef) (string, error) {
 					startVMWasCalled = true
 					return "", nil
 				},
-				getNextID: func(id int) (int, error) {
+				getNextID: func(ctx context.Context, id int) (int, error) {
 					return 101, nil
 				},
 			}

--- a/builder/proxmox/common/step_start_vm_test.go
+++ b/builder/proxmox/common/step_start_vm_test.go
@@ -454,12 +454,14 @@ func TestStartVM_AssertInitialQuemuConfig(t *testing.T) {
 			config: &Config{
 				PCIDevices: []pciDeviceConfig{
 					{
+						Host:       "0000:00:1f.0",
 						HideROMBAR: false,
 					},
 				},
 			},
 			assertQemuConfig: func(t *testing.T, config proxmox.ConfigQemu) {
-				assert.Equal(t, "true", config.QemuPCIDevices[0]["rombar"])
+				assert.Equal(t, "0000:00:1f.0", config.PciDevices[0].Raw.ID.String())
+				assert.Equal(t, true, *config.PciDevices[0].Raw.ROMbar)
 			},
 		},
 	}

--- a/builder/proxmox/common/step_type_boot_command.go
+++ b/builder/proxmox/common/step_type_boot_command.go
@@ -31,7 +31,7 @@ type bootCommandTemplateData struct {
 }
 
 type commandTyper interface {
-	Sendkey(*proxmox.VmRef, string) error
+	Sendkey(context.Context, *proxmox.VmRef, string) error
 }
 
 var _ commandTyper = &proxmox.Client{}

--- a/builder/proxmox/common/step_type_boot_command_test.go
+++ b/builder/proxmox/common/step_type_boot_command_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 type commandTyperMock struct {
-	sendkey func(*proxmox.VmRef, string) error
+	sendkey func(context.Context, *proxmox.VmRef, string) error
 }
 
-func (m commandTyperMock) Sendkey(ref *proxmox.VmRef, cmd string) error {
-	return m.sendkey(ref, cmd)
+func (m commandTyperMock) Sendkey(ctx context.Context, ref *proxmox.VmRef, cmd string) error {
+	return m.sendkey(ctx, ref, cmd)
 }
 
 var _ commandTyper = commandTyperMock{}
@@ -119,7 +119,7 @@ func TestTypeBootCommand(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			accumulator := strings.Builder{}
 			typer := commandTyperMock{
-				sendkey: func(ref *proxmox.VmRef, cmd string) error {
+				sendkey: func(ctx context.Context, ref *proxmox.VmRef, cmd string) error {
 					if !c.expectCallSendkey {
 						t.Error("Did not expect sendkey to be called")
 					}

--- a/builder/proxmox/common/step_upload_iso.go
+++ b/builder/proxmox/common/step_upload_iso.go
@@ -21,8 +21,8 @@ type stepUploadISO struct {
 }
 
 type uploader interface {
-	Upload(node string, storage string, contentType string, filename string, file io.Reader) error
-	DeleteVolume(vmr *proxmoxapi.VmRef, storageName string, volumeName string) (exitStatus interface{}, err error)
+	Upload(ctx context.Context, node string, storage string, contentType string, filename string, file io.Reader) error
+	DeleteVolume(ctx context.Context, vmr *proxmoxapi.VmRef, storageName string, volumeName string) (exitStatus interface{}, err error)
 }
 
 var _ uploader = &proxmoxapi.Client{}
@@ -72,7 +72,7 @@ func (s *stepUploadISO) Run(ctx context.Context, state multistep.StateBag) multi
 	}
 
 	filename := filepath.Base(isoPath)
-	err = client.Upload(c.Node, s.ISO.ISOStoragePool, "iso", filename, r)
+	err = client.Upload(ctx, c.Node, s.ISO.ISOStoragePool, "iso", filename, r)
 	if err != nil {
 		state.Put("error", err)
 		ui.Error(err.Error())
@@ -102,7 +102,7 @@ func (s *stepUploadISO) Cleanup(state multistep.StateBag) {
 		vmRef.SetNode(c.Node)
 		vmRef.SetVmType("qemu")
 
-		_, err := client.DeleteVolume(vmRef, s.ISO.ISOStoragePool, s.ISO.ISOFile)
+		_, err := client.DeleteVolume(context.TODO(), vmRef, s.ISO.ISOStoragePool, s.ISO.ISOFile)
 		if err != nil {
 			state.Put("error", err)
 			ui.Error(fmt.Sprintf("delete volume failed: %s", err.Error()))

--- a/builder/proxmox/common/step_upload_iso_test.go
+++ b/builder/proxmox/common/step_upload_iso_test.go
@@ -22,7 +22,7 @@ type uploaderMock struct {
 	deleteWasCalled bool
 }
 
-func (m *uploaderMock) Upload(node string, storage string, contentType string, filename string, file io.Reader) error {
+func (m *uploaderMock) Upload(ctx context.Context, node string, storage string, contentType string, filename string, file io.Reader) error {
 	m.uploadWasCalled = true
 	if m.uploadFail {
 		return fmt.Errorf("Testing induced Upload failure")
@@ -30,7 +30,7 @@ func (m *uploaderMock) Upload(node string, storage string, contentType string, f
 	return nil
 }
 
-func (m *uploaderMock) DeleteVolume(vmr *proxmox.VmRef, storageName string, volumeName string) (exitStatus interface{}, err error) {
+func (m *uploaderMock) DeleteVolume(ctx context.Context, vmr *proxmox.VmRef, storageName string, volumeName string) (exitStatus interface{}, err error) {
 	m.deleteWasCalled = true
 	if m.deleteFail {
 		return nil, fmt.Errorf("Testing induced DeleteVolume failure")

--- a/builder/proxmox/iso/builder.go
+++ b/builder/proxmox/iso/builder.go
@@ -49,7 +49,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 type isoVMCreator struct{}
 
-func (*isoVMCreator) Create(vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQemu, state multistep.StateBag) error {
+func (*isoVMCreator) Create(ctx context.Context, vmRef *proxmoxapi.VmRef, config proxmoxapi.ConfigQemu, state multistep.StateBag) error {
 	client := state.Get("proxmoxClient").(*proxmoxapi.Client)
-	return config.Create(vmRef, client)
+	return config.Create(ctx, vmRef, client)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.7
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20241022204517-b149708f750b
+	github.com/Telmate/proxmox-api-go v0.0.0-20241205214358-976ef5098918
 	github.com/hashicorp/go-getter/v2 v2.2.2
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/packer-plugin-sdk v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nu
 github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6 h1:w0E0fgc1YafGEh5cROhlROMWXiNoZqApk2PDN0M1+Ns=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/Telmate/proxmox-api-go v0.0.0-20241022204517-b149708f750b h1:vgK9CbUZpd37RYab6lCEQTyP0fw/Ygq5NOWctBI5rpA=
-github.com/Telmate/proxmox-api-go v0.0.0-20241022204517-b149708f750b/go.mod h1:Gu6n6vEn1hlyFUkjrvU+X1fdgaSXLoM9HKYYJqy1fsY=
+github.com/Telmate/proxmox-api-go v0.0.0-20241205214358-976ef5098918 h1:dfs2cVaIHtia0uq/Vo6y8pF0McWadzFPW7mAB46d1JI=
+github.com/Telmate/proxmox-api-go v0.0.0-20241205214358-976ef5098918/go.mod h1:Gu6n6vEn1hlyFUkjrvU+X1fdgaSXLoM9HKYYJqy1fsY=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION



### Description
What code changed, and why?

Hello, Maintainer of [Telmate/proxmox-api-go](https://github.com/Telmate/proxmox-api-go) here. Thought I'd help get this project over the context hurdle that was added in [976ef5098918469fca1cf843f96df391264410da](https://github.com/Telmate/proxmox-api-go/commit/976ef5098918469fca1cf843f96df391264410da).

Added the `context.Context` everywhere it was missing. Where I didn't know what the right call was I added `context.TODO()` directly.

Refactored the Qemu network interfaces to use the upstream [QemuNetworkInterfaces](https://github.com/Telmate/proxmox-api-go/blob/81c14ce502d86ccf7e905ee35e9a705eb2874d35/proxmox/config__qemu__network.go#L354).

Refactored the Qemu PCI devices to use the upstream [QemuPciDevices](https://github.com/Telmate/proxmox-api-go/blob/81c14ce502d86ccf7e905ee35e9a705eb2874d35/proxmox/config__qemu__pcie.go#L11). However there is a problem there. The following properties have not yet been implemented upstream:

- `mdev`
- `romfile`
- `legacy-igd`

I'm of the understanding these features are rarely used. As someone would have opened a ticket for it otherwise.

For `mdev` we have an [issue](https://github.com/Telmate/proxmox-api-go/issues/526) and it will be fixed.
However for `romfile` and `legacy-igd` we are unsure how they would fit in our current data structure.

### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Related to #339


### Rollback Plan

n/a

### Changes to Security Controls

n/a

