### PR TITLE
Respect proxy environment variables for Proxmox API connections

### DIFF
--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -6,6 +6,7 @@ package proxmox
 import (
 	"crypto/tls"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
@@ -16,7 +17,20 @@ func newProxmoxClient(config Config) (*proxmox.Client, error) {
 		InsecureSkipVerify: config.SkipCertValidation,
 	}
 
-	client, err := proxmox.NewClient(strings.TrimSuffix(config.proxmoxURL.String(), "/"), nil, "", tlsConfig, "", int(config.TaskTimeout.Seconds()))
+	// Create an HTTP client that respects standard proxy environment variables
+	// (HTTPS_PROXY, HTTP_PROXY, NO_PROXY). The upstream Telmate library sets
+	// Proxy: nil when no explicit proxy string is provided, which disables
+	// proxy support entirely. By passing our own http.Client, we ensure
+	// proxy env vars are honored.
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig:    tlsConfig,
+			DisableCompression: true,
+			Proxy:              http.ProxyFromEnvironment,
+		},
+	}
+
+	client, err := proxmox.NewClient(strings.TrimSuffix(config.proxmoxURL.String(), "/"), httpClient, "", tlsConfig, "", int(config.TaskTimeout.Seconds()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #346

## Summary

The Proxmox API client ignores standard proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) because the upstream Telmate library creates an `http.Transport` with `Proxy: nil` when no explicit proxy string is provided.

This PR creates an `http.Client` with `http.ProxyFromEnvironment` and passes it to `proxmox.NewClient()`, so proxy env vars are respected. When no proxy env vars are set, behavior is unchanged since `http.ProxyFromEnvironment` returns nil.

## Context

This affects users running packer in environments where the Proxmox server is only reachable through an HTTP proxy (e.g., on-prem Proxmox accessed from a cloud-hosted CI runner via a VPN proxy). Currently the only workaround is to use tools like `proxychains` to force proxy usage.

## Changes

- `builder/proxmox/common/client.go`: Create an `http.Client` with `Proxy: http.ProxyFromEnvironment` and pass it to `proxmox.NewClient()` instead of `nil`

## Testing

- Verified the fix compiles successfully
- When `HTTPS_PROXY` is not set, `http.ProxyFromEnvironment` returns nil, so existing behavior is preserved
- When `HTTPS_PROXY` is set, the Go HTTP client will use it for Proxmox API connections