### PR TITLE
[Issue 342] Use VM name as fallback when looking up existing template with -force

### DIFF
--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -63,12 +63,19 @@ func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
 		}
 		log.Printf("found VM with ID %d", vmRef.VmId())
 	} else {
-		log.Printf("looking up VMs with name '%s'", c.TemplateName)
-		vmRefs, err := client.GetVmRefsByName(c.TemplateName)
+		// Fall back to VMName when TemplateName is not set, matching the
+		// behaviour in stepFinalizeTemplateConfig where VMName is used as
+		// the default template name.
+		templateName := c.TemplateName
+		if templateName == "" {
+			templateName = c.VMName
+		}
+		log.Printf("looking up VMs with name '%s'", templateName)
+		vmRefs, err := client.GetVmRefsByName(templateName)
 		if err != nil {
 			// expect an error if no VMs are found
 			// the error string is defined in GetVmRefsByName() of proxmox-api-go
-			notFoundError := fmt.Sprintf("vm '%s' not found", c.TemplateName)
+			notFoundError := fmt.Sprintf("vm '%s' not found", templateName)
 			if err.Error() == notFoundError {
 				log.Println(err.Error())
 				return &proxmox.VmRef{}, nil
@@ -80,10 +87,10 @@ func getExistingTemplate(c *Config, client vmStarter) (*proxmox.VmRef, error) {
 			for _, vmr := range vmRefs {
 				vmIDs = append(vmIDs, vmr.VmId())
 			}
-			return &proxmox.VmRef{}, fmt.Errorf("found multiple VMs with name '%s', IDs: %v", c.TemplateName, vmIDs)
+			return &proxmox.VmRef{}, fmt.Errorf("found multiple VMs with name '%s', IDs: %v", templateName, vmIDs)
 		}
 		vmRef = vmRefs[0]
-		log.Printf("found VM with name '%s' (ID: %d)", c.TemplateName, vmRef.VmId())
+		log.Printf("found VM with name '%s' (ID: %d)", templateName, vmRef.VmId())
 	}
 	log.Printf("check if VM %d is a template", vmRef.VmId())
 	vmConfig, err := client.GetVmConfig(vmRef)

--- a/builder/proxmox/common/step_start_vm_test.go
+++ b/builder/proxmox/common/step_start_vm_test.go
@@ -391,6 +391,29 @@ func TestStartVMWithForce(t *testing.T) {
 				return map[string]interface{}{"template": 1.0}, nil
 			},
 		},
+		{
+			name: "delete VM when template_name is empty, falls back to vm_name",
+			config: &Config{
+				PackerConfig: common.PackerConfig{
+					PackerForce: true,
+				},
+				VMName: "mockVM",
+				// TemplateName deliberately left empty
+			},
+			expectedCallToDelete: true,
+			expectedAction:       multistep.ActionContinue,
+			mockGetVmRefsByName: func(vmName string) (vmrs []*proxmox.VmRef, err error) {
+				if vmName != "mockVM" {
+					return nil, fmt.Errorf("expected lookup by VMName 'mockVM', got '%s'", vmName)
+				}
+				return []*proxmox.VmRef{
+					proxmox.NewVmRef(100),
+				}, nil
+			},
+			mockGetVmConfig: func(vmr *proxmox.VmRef) (map[string]interface{}, error) {
+				return map[string]interface{}{"template": 1.0}, nil
+			},
+		},
 	}
 
 	for _, c := range cs {


### PR DESCRIPTION
### Description

When using `-force` without explicitly setting `template_name`, the plugin
should find and delete the existing template before creating a new one.

The documentation for `template_name` states "Defaults to the generated name
used during creation", and `stepFinalizeTemplateConfig` already falls back to
`VMName` when `TemplateName` is empty (lines 37-40). However,
`getExistingTemplate()` used `TemplateName` directly for the name-based lookup
— when it's empty, it searched for VMs with name `""`, found nothing, and
silently skipped the deletion.

This change adds the same fallback logic so the `-force` template lookup is
consistent with how the template is actually named.

Includes a test case verifying that `VMName` is used for the lookup when
`TemplateName` is not configured.

### Resolved Issues

Closes #342

### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

None.