### PR TITLE
[Issue 346] Respect HTTPS_PROXY and HTTP_PROXY environment variables

### DIFF
--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -6,6 +6,7 @@ package proxmox
 import (
 	"crypto/tls"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
@@ -16,7 +17,14 @@ func newProxmoxClient(config Config) (*proxmox.Client, error) {
 		InsecureSkipVerify: config.SkipCertValidation,
 	}
 
-	client, err := proxmox.NewClient(strings.TrimSuffix(config.proxmoxURL.String(), "/"), nil, "", tlsConfig, "", int(config.TaskTimeout.Seconds()))
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+			Proxy:           http.ProxyFromEnvironment,
+		},
+	}
+
+	client, err := proxmox.NewClient(strings.TrimSuffix(config.proxmoxURL.String(), "/"), httpClient, "", tlsConfig, "", int(config.TaskTimeout.Seconds()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

The plugin currently passes `nil` as the HTTP client to `proxmox.NewClient()`.
The upstream library's `NewSession()` handles this by creating a transport with
`Proxy: nil`, which explicitly disables Go's standard proxy environment variable
handling. Users behind corporate proxies cannot use the plugin even when
`HTTPS_PROXY` is correctly configured.

The root cause is in `session.go` of `proxmox-api-go` — when `hclient` is `nil`
and `proxyString` is empty, it builds a transport with `Proxy: nil` rather than
`http.ProxyFromEnvironment`.

This change creates a configured `http.Client` with `http.ProxyFromEnvironment`
and passes it to `proxmox.NewClient()`. Since a non-nil client is provided, the
upstream library uses it directly, bypassing its own transport creation. When no
proxy environment variables are set, behaviour is identical to the current
implementation.

This follows the same approach used by Terraform providers and other Go HTTP
clients for proxy support.

### Resolved Issues

Closes #346

### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

HTTP proxy configuration is read from standard environment variables
(`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`). This is standard Go behaviour via
`http.ProxyFromEnvironment` and does not introduce new attack surface — the
proxy must be explicitly configured in the user's environment.