### PR TITLE
[Issues 312, 332] Mark required fields in docs, add TPM config documentation

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -39,6 +39,24 @@ in the image's Cloud-Init settings for provisioning.
 
 ### Required:
 
+<!-- Code generated from the comments of the Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `proxmox_url` (string) - URL to the Proxmox API, including the full path,
+  so `https://<server>:<port>/api2/json` for example.
+  Can also be set via the `PROXMOX_URL` environment variable.
+
+- `username` (string) - Username when authenticating to Proxmox, including
+  the realm. For example `user@pve` to use the local Proxmox realm. When using
+  token authentication, the username must include the token id after an exclamation
+  mark. For example, `user@pve!tokenid`.
+  Can also be set via the `PROXMOX_USERNAME` environment variable.
+
+- `node` (string) - Which node in the Proxmox cluster to start the virtual
+  machine on during creation.
+
+<!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
+
+
 <!-- Code generated from the comments of the Config struct in builder/proxmox/clone/config.go; DO NOT EDIT MANUALLY -->
 
 - `clone_vm` (string) - The name of the VM Packer should clone and build from.
@@ -139,17 +157,7 @@ boot time.
 
 - `boot_key_interval` (duration string | ex: "1h5m2s") - Boot Key Interval
 
-- `proxmox_url` (string) - URL to the Proxmox API, including the full path,
-  so `https://<server>:<port>/api2/json` for example.
-  Can also be set via the `PROXMOX_URL` environment variable.
-
 - `insecure_skip_tls_verify` (bool) - Skip validating the certificate.
-
-- `username` (string) - Username when authenticating to Proxmox, including
-  the realm. For example `user@pve` to use the local Proxmox realm. When using
-  token authentication, the username must include the token id after an exclamation
-  mark. For example, `user@pve!tokenid`.
-  Can also be set via the `PROXMOX_USERNAME` environment variable.
 
 - `password` (string) - Password for the user.
   For API tokens please use `token`.
@@ -162,9 +170,6 @@ boot time.
   Can also be set via the `PROXMOX_TOKEN` environment variable.
   Either `password` or `token` must be specifed. If both are set,
   `token` takes precedence.
-
-- `node` (string) - Which node in the Proxmox cluster to start the virtual
-  machine on during creation.
 
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
@@ -824,6 +829,47 @@ Usage example (JSON):
   Defaults to `4m`.
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
+
+
+### TPM Config
+
+<!-- Code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+Set the tpmstate storage options.
+
+HCL2 example:
+
+```hcl
+
+	tpm_config {
+	  tpm_storage_pool = "local"
+	  tpm_version      = "v1.2"
+	}
+
+```
+Usage example (JSON):
+
+```json
+
+	"tpm_config": {
+	  "tpm_storage_pool": "local",
+	  "tpm_version": "v1.2"
+	}
+
+```
+
+<!-- End of code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; -->
+
+
+#### Optional:
+
+<!-- Code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `tpm_storage_pool` (string) - Name of the Proxmox storage pool to store the TPM state on.
+
+- `tpm_version` (string) - Version of TPM spec. Can be `v1.2` or `v2.0` Defaults to `v2.0`.
+
+<!-- End of code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; -->
 
 
 ### VirtIO RNG device

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -35,6 +35,24 @@ in the image's Cloud-Init settings for provisioning.
 
 ### Required:
 
+<!-- Code generated from the comments of the Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `proxmox_url` (string) - URL to the Proxmox API, including the full path,
+  so `https://<server>:<port>/api2/json` for example.
+  Can also be set via the `PROXMOX_URL` environment variable.
+
+- `username` (string) - Username when authenticating to Proxmox, including
+  the realm. For example `user@pve` to use the local Proxmox realm. When using
+  token authentication, the username must include the token id after an exclamation
+  mark. For example, `user@pve!tokenid`.
+  Can also be set via the `PROXMOX_USERNAME` environment variable.
+
+- `node` (string) - Which node in the Proxmox cluster to start the virtual
+  machine on during creation.
+
+<!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->
+
+
 <!-- Code generated from the comments of the Config struct in builder/proxmox/iso/config.go; DO NOT EDIT MANUALLY -->
 
 - `boot_iso` (common.ISOsConfig) - Boot ISO attached to the virtual machine.
@@ -74,17 +92,7 @@ in the image's Cloud-Init settings for provisioning.
 
 - `boot_key_interval` (duration string | ex: "1h5m2s") - Boot Key Interval
 
-- `proxmox_url` (string) - URL to the Proxmox API, including the full path,
-  so `https://<server>:<port>/api2/json` for example.
-  Can also be set via the `PROXMOX_URL` environment variable.
-
 - `insecure_skip_tls_verify` (bool) - Skip validating the certificate.
-
-- `username` (string) - Username when authenticating to Proxmox, including
-  the realm. For example `user@pve` to use the local Proxmox realm. When using
-  token authentication, the username must include the token id after an exclamation
-  mark. For example, `user@pve!tokenid`.
-  Can also be set via the `PROXMOX_USERNAME` environment variable.
 
 - `password` (string) - Password for the user.
   For API tokens please use `token`.
@@ -97,9 +105,6 @@ in the image's Cloud-Init settings for provisioning.
   Can also be set via the `PROXMOX_TOKEN` environment variable.
   Either `password` or `token` must be specifed. If both are set,
   `token` takes precedence.
-
-- `node` (string) - Which node in the Proxmox cluster to start the virtual
-  machine on during creation.
 
 - `pool` (string) - Name of resource pool to create virtual machine in.
 
@@ -665,6 +670,47 @@ Usage example (JSON):
   Defaults to `4m`.
 
 <!-- End of code generated from the comments of the efiConfig struct in builder/proxmox/common/config.go; -->
+
+
+### TPM Config
+
+<!-- Code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+Set the tpmstate storage options.
+
+HCL2 example:
+
+```hcl
+
+	tpm_config {
+	  tpm_storage_pool = "local"
+	  tpm_version      = "v1.2"
+	}
+
+```
+Usage example (JSON):
+
+```json
+
+	"tpm_config": {
+	  "tpm_storage_pool": "local",
+	  "tpm_version": "v1.2"
+	}
+
+```
+
+<!-- End of code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; -->
+
+
+#### Optional:
+
+<!-- Code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `tpm_storage_pool` (string) - Name of the Proxmox storage pool to store the TPM state on.
+
+- `tpm_version` (string) - Version of TPM spec. Can be `v1.2` or `v2.0` Defaults to `v2.0`.
+
+<!-- End of code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; -->
 
 
 ### VirtIO RNG device

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -79,12 +79,12 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool                         `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool                         `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool                         `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	ProxmoxURLRaw             *string                       `mapstructure:"proxmox_url" cty:"proxmox_url" hcl:"proxmox_url"`
+	ProxmoxURLRaw             *string                       `mapstructure:"proxmox_url" required:"true" cty:"proxmox_url" hcl:"proxmox_url"`
 	SkipCertValidation        *bool                         `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
-	Username                  *string                       `mapstructure:"username" cty:"username" hcl:"username"`
+	Username                  *string                       `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
 	Password                  *string                       `mapstructure:"password" cty:"password" hcl:"password"`
 	Token                     *string                       `mapstructure:"token" cty:"token" hcl:"token"`
-	Node                      *string                       `mapstructure:"node" cty:"node" hcl:"node"`
+	Node                      *string                       `mapstructure:"node" required:"true" cty:"node" hcl:"node"`
 	Pool                      *string                       `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	TaskTimeout               *string                       `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                       `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	// URL to the Proxmox API, including the full path,
 	// so `https://<server>:<port>/api2/json` for example.
 	// Can also be set via the `PROXMOX_URL` environment variable.
-	ProxmoxURLRaw string `mapstructure:"proxmox_url"`
+	ProxmoxURLRaw string `mapstructure:"proxmox_url" required:"true"`
 	proxmoxURL    *url.URL
 	// Skip validating the certificate.
 	SkipCertValidation bool `mapstructure:"insecure_skip_tls_verify"`
@@ -62,7 +62,7 @@ type Config struct {
 	// token authentication, the username must include the token id after an exclamation
 	// mark. For example, `user@pve!tokenid`.
 	// Can also be set via the `PROXMOX_USERNAME` environment variable.
-	Username string `mapstructure:"username"`
+	Username string `mapstructure:"username" required:"true"`
 	// Password for the user.
 	// For API tokens please use `token`.
 	// Can also be set via the `PROXMOX_PASSWORD` environment variable.
@@ -77,7 +77,7 @@ type Config struct {
 	Token string `mapstructure:"token"`
 	// Which node in the Proxmox cluster to start the virtual
 	// machine on during creation.
-	Node string `mapstructure:"node"`
+	Node string `mapstructure:"node" required:"true"`
 	// Name of resource pool to create virtual machine in.
 	Pool string `mapstructure:"pool"`
 	// `task_timeout` (duration string | ex: "10m") - The timeout for
@@ -434,7 +434,7 @@ type efiConfig struct {
 //
 // ```
 type tpmConfig struct {
-	// Name of the Proxmox storage pool to store the EFI disk on.
+	// Name of the Proxmox storage pool to store the TPM state on.
 	TPMStoragePool string `mapstructure:"tpm_storage_pool"`
 	// Version of TPM spec. Can be `v1.2` or `v2.0` Defaults to `v2.0`.
 	Version string `mapstructure:"tpm_version"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -78,12 +78,12 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool                 `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool                 `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool                 `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	ProxmoxURLRaw             *string               `mapstructure:"proxmox_url" cty:"proxmox_url" hcl:"proxmox_url"`
+	ProxmoxURLRaw             *string               `mapstructure:"proxmox_url" required:"true" cty:"proxmox_url" hcl:"proxmox_url"`
 	SkipCertValidation        *bool                 `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
-	Username                  *string               `mapstructure:"username" cty:"username" hcl:"username"`
+	Username                  *string               `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
 	Password                  *string               `mapstructure:"password" cty:"password" hcl:"password"`
 	Token                     *string               `mapstructure:"token" cty:"token" hcl:"token"`
-	Node                      *string               `mapstructure:"node" cty:"node" hcl:"node"`
+	Node                      *string               `mapstructure:"node" required:"true" cty:"node" hcl:"node"`
 	Pool                      *string               `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	TaskTimeout               *string               `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string               `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -79,12 +79,12 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool                         `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool                         `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool                         `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	ProxmoxURLRaw             *string                       `mapstructure:"proxmox_url" cty:"proxmox_url" hcl:"proxmox_url"`
+	ProxmoxURLRaw             *string                       `mapstructure:"proxmox_url" required:"true" cty:"proxmox_url" hcl:"proxmox_url"`
 	SkipCertValidation        *bool                         `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
-	Username                  *string                       `mapstructure:"username" cty:"username" hcl:"username"`
+	Username                  *string                       `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
 	Password                  *string                       `mapstructure:"password" cty:"password" hcl:"password"`
 	Token                     *string                       `mapstructure:"token" cty:"token" hcl:"token"`
-	Node                      *string                       `mapstructure:"node" cty:"node" hcl:"node"`
+	Node                      *string                       `mapstructure:"node" required:"true" cty:"node" hcl:"node"`
 	Pool                      *string                       `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	TaskTimeout               *string                       `mapstructure:"task_timeout" cty:"task_timeout" hcl:"task_timeout"`
 	VMName                    *string                       `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -2,17 +2,7 @@
 
 - `boot_key_interval` (duration string | ex: "1h5m2s") - Boot Key Interval
 
-- `proxmox_url` (string) - URL to the Proxmox API, including the full path,
-  so `https://<server>:<port>/api2/json` for example.
-  Can also be set via the `PROXMOX_URL` environment variable.
-
 - `insecure_skip_tls_verify` (bool) - Skip validating the certificate.
-
-- `username` (string) - Username when authenticating to Proxmox, including
-  the realm. For example `user@pve` to use the local Proxmox realm. When using
-  token authentication, the username must include the token id after an exclamation
-  mark. For example, `user@pve!tokenid`.
-  Can also be set via the `PROXMOX_USERNAME` environment variable.
 
 - `password` (string) - Password for the user.
   For API tokens please use `token`.
@@ -25,9 +15,6 @@
   Can also be set via the `PROXMOX_TOKEN` environment variable.
   Either `password` or `token` must be specifed. If both are set,
   `token` takes precedence.
-
-- `node` (string) - Which node in the Proxmox cluster to start the virtual
-  machine on during creation.
 
 - `pool` (string) - Name of resource pool to create virtual machine in.
 

--- a/docs-partials/builder/proxmox/common/Config-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-required.mdx
@@ -1,0 +1,16 @@
+<!-- Code generated from the comments of the Config struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `proxmox_url` (string) - URL to the Proxmox API, including the full path,
+  so `https://<server>:<port>/api2/json` for example.
+  Can also be set via the `PROXMOX_URL` environment variable.
+
+- `username` (string) - Username when authenticating to Proxmox, including
+  the realm. For example `user@pve` to use the local Proxmox realm. When using
+  token authentication, the username must include the token id after an exclamation
+  mark. For example, `user@pve!tokenid`.
+  Can also be set via the `PROXMOX_USERNAME` environment variable.
+
+- `node` (string) - Which node in the Proxmox cluster to start the virtual
+  machine on during creation.
+
+<!-- End of code generated from the comments of the Config struct in builder/proxmox/common/config.go; -->

--- a/docs-partials/builder/proxmox/common/tpmConfig-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/tpmConfig-not-required.mdx
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the tpmConfig struct in builder/proxmox/common/config.go; DO NOT EDIT MANUALLY -->
 
-- `tpm_storage_pool` (string) - Name of the Proxmox storage pool to store the EFI disk on.
+- `tpm_storage_pool` (string) - Name of the Proxmox storage pool to store the TPM state on.
 
 - `tpm_version` (string) - Version of TPM spec. Can be `v1.2` or `v2.0` Defaults to `v2.0`.
 

--- a/docs/builders/clone.mdx
+++ b/docs/builders/clone.mdx
@@ -33,6 +33,8 @@ to you to use it or delete it.
 
 ### Required:
 
+@include 'builder/proxmox/common/Config-required.mdx'
+
 @include 'builder/proxmox/clone/Config-required.mdx'
 
 @include 'packer-plugin-sdk/multistep/commonsteps/CDConfig.mdx'
@@ -102,6 +104,14 @@ to you to use it or delete it.
 #### Optional:
 
 @include 'builder/proxmox/common/efiConfig-not-required.mdx'
+
+### TPM Config
+
+@include 'builder/proxmox/common/tpmConfig.mdx'
+
+#### Optional:
+
+@include 'builder/proxmox/common/tpmConfig-not-required.mdx'
 
 ### VirtIO RNG device
 

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -29,6 +29,8 @@ to you to use it or delete it.
 
 ### Required:
 
+@include 'builder/proxmox/common/Config-required.mdx'
+
 @include 'builder/proxmox/iso/Config-required.mdx'
 
 ### Optional:
@@ -89,6 +91,14 @@ to you to use it or delete it.
 #### Optional:
 
 @include 'builder/proxmox/common/efiConfig-not-required.mdx'
+
+### TPM Config
+
+@include 'builder/proxmox/common/tpmConfig.mdx'
+
+#### Optional:
+
+@include 'builder/proxmox/common/tpmConfig-not-required.mdx'
 
 ### VirtIO RNG device
 


### PR DESCRIPTION
### Description

Three documentation fixes:

**Issue #312 — Required fields incorrectly documented as optional**

The `proxmox_url`, `username`, and `node` fields are all validated as required
in `Prepare()` — builds fail with `"<field> must be specified"` if any are
omitted. However, their struct tags lacked `required:"true"`, so `packer-sdc
struct-markdown` generated them into `Config-not-required.mdx`. Added the tags
and regenerated documentation. These fields now appear in the Required section
of both builder pages.

Note: `password` and `token` are deliberately left without the tag — they are
conditionally required (either one must be set, not both), and the existing
documentation comment already communicates this.

**Issue #332 — TPM configuration missing from builder documentation**

The TPM doc partials (`tpmConfig.mdx`, `tpmConfig-not-required.mdx`) were
correctly generated from the `tpmConfig` struct but neither `iso.mdx` nor
`clone.mdx` included them via `@include` directives. Added the TPM Config
section to both builder pages, placed after EFI Config alongside other
firmware/security configuration.

**Bonus fix — TPM storage pool comment**

The `tpmConfig.TPMStoragePool` doc comment incorrectly referenced "EFI disk"
(copy-paste from `efiConfig`). Corrected to "TPM state".

All generated files (`*.hcl2spec.go`, `Config-required.mdx`,
`Config-not-required.mdx`, `tpmConfig-not-required.mdx`, `.web-docs/`) are
included.

### Resolved Issues

Closes #312
Closes #332

### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

None. Documentation changes only.