### PR TITLE
QEMU User Agent type configuration to allow NetBSD, OpenBSD, and Solaris installations

### DIFF
--- a/.web-docs/components/builder/clone/README.md
+++ b/.web-docs/components/builder/clone/README.md
@@ -248,9 +248,10 @@ boot time.
     ]
     ```
 
-- `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
-  then `qemu-guest-agent` must be installed on the guest. When disabled, then
-  `ssh_host` should be used. Defaults to `true`.
+- `qemu_agent` (string) - Configures QEMU Agent option for this VM.
+  Supported values are 'virtio', 'isa' or 'disabled'.
+  When disabled, then `ssh_host` should be used.
+  Defaults to 'virtio'.
 
 - `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -183,9 +183,10 @@ in the image's Cloud-Init settings for provisioning.
     ]
     ```
 
-- `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
-  then `qemu-guest-agent` must be installed on the guest. When disabled, then
-  `ssh_host` should be used. Defaults to `true`.
+- `qemu_agent` (string) - Configures QEMU Agent option for this VM.
+  Supported values are 'virtio', 'isa' or 'disabled'.
+  When disabled, then `ssh_host` should be used.
+  Defaults to 'virtio'.
 
 - `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -109,7 +109,7 @@ type FlatConfig struct {
 	Disks                           []proxmox.FlatdiskConfig      `mapstructure:"disks" cty:"disks" hcl:"disks"`
 	PCIDevices                      []proxmox.FlatpciDeviceConfig `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                         []string                      `mapstructure:"serials" cty:"serials" hcl:"serials"`
-	Agent                           *bool                         `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
+	Agent                           *string                       `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController                  *string                       `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                          *bool                         `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
 	DisableKVM                      *bool                         `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`
@@ -241,7 +241,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disks":                               &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*proxmox.FlatdiskConfig)(nil).HCL2Spec())},
 		"pci_devices":                         &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*proxmox.FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                             &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
-		"qemu_agent":                          &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
+		"qemu_agent":                          &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.String, Required: false},
 		"scsi_controller":                     &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                              &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},
 		"disable_kvm":                         &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -158,10 +158,11 @@ type Config struct {
 	//   ]
 	//   ```
 	Serials []string `mapstructure:"serials"`
-	// Enables QEMU Agent option for this VM. When enabled,
-	// then `qemu-guest-agent` must be installed on the guest. When disabled, then
-	// `ssh_host` should be used. Defaults to `true`.
-	Agent config.Trilean `mapstructure:"qemu_agent"`
+	// Configures QEMU Agent option for this VM.
+	// Supported values are 'virtio', 'isa' or 'disabled'.
+	// When disabled, then `ssh_host` should be used.
+	// Defaults to 'virtio'.
+	Agent string `mapstructure:"qemu_agent"`
 	// The SCSI controller model to emulate. Can be `lsi`,
 	// `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
 	// Defaults to `lsi`.
@@ -611,9 +612,13 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 		warnings = append(warnings, "proxmox is deprecated, please use proxmox-iso instead")
 	}
 
-	// Default qemu_agent to true
-	if c.Agent != config.TriFalse {
-		c.Agent = config.TriTrue
+	switch c.Agent {
+		case "virtio", "isa":
+		case "":
+			log.Printf("qemu_agent not specified, defaulting to `virtio`")
+			c.Agent = "virtio"
+		default:
+			errs = packersdk.MultiErrorAppend(errs, errors.New("qemu_agent type field must be `virtio` , `isa` or `disabled`"))
 	}
 
 	packersdk.LogSecretFilter.Set(c.Password)

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -108,7 +108,7 @@ type FlatConfig struct {
 	Disks                           []FlatdiskConfig      `mapstructure:"disks" cty:"disks" hcl:"disks"`
 	PCIDevices                      []FlatpciDeviceConfig `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                         []string              `mapstructure:"serials" cty:"serials" hcl:"serials"`
-	Agent                           *bool                 `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
+	Agent                           *string               `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController                  *string               `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                          *bool                 `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
 	DisableKVM                      *bool                 `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -234,7 +234,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disks":                               &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*FlatdiskConfig)(nil).HCL2Spec())},
 		"pci_devices":                         &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                             &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
-		"qemu_agent":                          &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
+		"qemu_agent":                          &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.String, Required: false},
 		"scsi_controller":                     &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                              &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},
 		"disable_kvm":                         &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -58,8 +58,8 @@ func TestAgentSetToDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if c.Agent() != "disabled" {
-		t.Errorf("Expected Agent to be disabled, got %s", c.Agent)
+	if c.Agent != "disabled" {
+		t.Errorf("Expected Agent to be 'disabled', got %s", c.Agent)
 	}
 }
 

--- a/builder/proxmox/common/config_test.go
+++ b/builder/proxmox/common/config_test.go
@@ -48,9 +48,9 @@ func TestRequiredParameters(t *testing.T) {
 	}
 }
 
-func TestAgentSetToFalse(t *testing.T) {
+func TestAgentSetToDisabled(t *testing.T) {
 	cfg := mandatoryConfig(t)
-	cfg["qemu_agent"] = false
+	cfg["qemu_agent"] = "disabled"
 
 	var c Config
 	_, _, err := c.Prepare(&c, cfg)
@@ -58,8 +58,8 @@ func TestAgentSetToFalse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if c.Agent.False() != true {
-		t.Errorf("Expected Agent to be false, got %t", c.Agent.True())
+	if c.Agent() != "disabled" {
+		t.Errorf("Expected Agent to be disabled, got %s", c.Agent)
 	}
 }
 

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	"github.com/hashicorp/packer-plugin-sdk/template/config"
+	// "github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 // stepStartVM takes the given configuration and starts a VM on the given Proxmox node.
@@ -285,15 +285,29 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 	return multistep.ActionContinue
 }
 
-func generateAgentConfig(agent config.Trilean) *proxmox.QemuGuestAgent {
-	var enableAgent bool
+func generateAgentConfig(agent string) *proxmox.QemuGuestAgent {
+	var enableAgent, enableFreeze, enableFsTrim bool
+	var agentType proxmox.QemuGuestAgentType
 
-	if agent.True() {
-		enableAgent = true
-	}
+	switch agent {
+	case "virtio", "isa":
+		enableAgent  = true
+		enableFreeze = true
+		enableFsTrim = true
+		agentType = proxmox.QemuGuestAgentType(agent)
 
-	return &proxmox.QemuGuestAgent{
-		Enable: &enableAgent,
+		return &proxmox.QemuGuestAgent{
+			Enable: &enableAgent,
+			Freeze: &enableFreeze,
+			FsTrim: &enableFsTrim,
+			Type:   &agentType,
+		}
+
+	default: // "disabled" or unrecognized string
+		enableAgent = false
+		return &proxmox.QemuGuestAgent{
+			Enable: &enableAgent,
+		}
 	}
 }
 

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -245,7 +245,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disks":                               &hcldec.BlockListSpec{TypeName: "disks", Nested: hcldec.ObjectSpec((*proxmox.FlatdiskConfig)(nil).HCL2Spec())},
 		"pci_devices":                         &hcldec.BlockListSpec{TypeName: "pci_devices", Nested: hcldec.ObjectSpec((*proxmox.FlatpciDeviceConfig)(nil).HCL2Spec())},
 		"serials":                             &hcldec.AttrSpec{Name: "serials", Type: cty.List(cty.String), Required: false},
-		"qemu_agent":                          &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
+		"qemu_agent":                          &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.String, Required: false},
 		"scsi_controller":                     &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
 		"onboot":                              &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},
 		"disable_kvm":                         &hcldec.AttrSpec{Name: "disable_kvm", Type: cty.Bool, Required: false},

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -109,7 +109,7 @@ type FlatConfig struct {
 	Disks                           []proxmox.FlatdiskConfig      `mapstructure:"disks" cty:"disks" hcl:"disks"`
 	PCIDevices                      []proxmox.FlatpciDeviceConfig `mapstructure:"pci_devices" cty:"pci_devices" hcl:"pci_devices"`
 	Serials                         []string                      `mapstructure:"serials" cty:"serials" hcl:"serials"`
-	Agent                           *bool                         `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
+	Agent                           *string                       `mapstructure:"qemu_agent" cty:"qemu_agent" hcl:"qemu_agent"`
 	SCSIController                  *string                       `mapstructure:"scsi_controller" cty:"scsi_controller" hcl:"scsi_controller"`
 	Onboot                          *bool                         `mapstructure:"onboot" cty:"onboot" hcl:"onboot"`
 	DisableKVM                      *bool                         `mapstructure:"disable_kvm" cty:"disable_kvm" hcl:"disable_kvm"`

--- a/builder/proxmox/iso/config_test.go
+++ b/builder/proxmox/iso/config_test.go
@@ -171,7 +171,7 @@ func TestDeprecatedBootISOOptionsAreConverted(t *testing.T) {
 
 func TestAgentSetToFalse(t *testing.T) {
 	cfg := mandatoryConfig(t)
-	cfg["qemu_agent"] = false
+	cfg["qemu_agent"] = "disabled"
 
 	var c Config
 	_, warn, err := c.Prepare(cfg)

--- a/builder/proxmox/iso/config_test.go
+++ b/builder/proxmox/iso/config_test.go
@@ -103,8 +103,8 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)
 	}
-	if b.config.Agent.True() != true {
-		t.Errorf("Expected Agent to be true, got %t", b.config.Agent.True())
+	if b.config.Agent != "virtio" {
+		t.Errorf("Expected Agent to be 'virtio', got %s", b.config.Agent)
 	}
 	if b.config.DisableKVM != false {
 		t.Errorf("Expected Disable KVM toggle to be false, got %t", b.config.DisableKVM)
@@ -169,18 +169,18 @@ func TestDeprecatedBootISOOptionsAreConverted(t *testing.T) {
 	}
 }
 
-func TestAgentSetToFalse(t *testing.T) {
+func TestAgentSetToDisabled(t *testing.T) {
 	cfg := mandatoryConfig(t)
 	cfg["qemu_agent"] = "disabled"
 
 	var c Config
-	_, warn, err := c.Prepare(cfg)
+	_, _, err := c.Prepare(&c, cfg)
 	if err != nil {
-		t.Fatal(err, warn)
+		t.Fatal(err)
 	}
 
-	if c.Agent.False() != true {
-		t.Errorf("Expected Agent to be false, got %t", c.Agent.True())
+	if c.Agent != "disabled" {
+		t.Errorf("Expected Agent to be 'disabled', got %s", c.Agent)
 	}
 }
 

--- a/docs-partials/builder/proxmox/common/Config-not-required.mdx
+++ b/docs-partials/builder/proxmox/common/Config-not-required.mdx
@@ -93,9 +93,10 @@
     ]
     ```
 
-- `qemu_agent` (boolean) - Enables QEMU Agent option for this VM. When enabled,
-  then `qemu-guest-agent` must be installed on the guest. When disabled, then
-  `ssh_host` should be used. Defaults to `true`.
+- `qemu_agent` (string) - Configures QEMU Agent option for this VM.
+  Supported values are 'virtio', 'isa' or 'disabled'.
+  When disabled, then `ssh_host` should be used.
+  Defaults to 'virtio'.
 
 - `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
   `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.


### PR DESCRIPTION
### Description

NetBSD, OpenBSD, and Solaris do not support a QEMU Guest Agent with VirtIO configuration. The current Proxmox builder only supports a QEMU Guest Agent in VirtIO-type configuration -> no possibility to install NetBSD, OpenBSD, or Solaris using the Proxmox builder, since these need an ISA-type configuration.

This pull request changes the `qemu_agent` parameter from boolean to string, allowing to configure the type of QEMU User Agent:

- `virtio`: VirtIO,
- `isa`: ISA (necessary for NetBSD, OpenBSD, Solaris)
- `disabled`: Turned off.

The update is a simplification of https://github.com/hashicorp/packer-plugin-proxmox/issues/276 , which was submitted ca. 2.5 years ago, and never got merged.

### Resolved Issues

Closes #363
